### PR TITLE
feat: allow updates to task logs after creation

### DIFF
--- a/internal/ui/cmds.go
+++ b/internal/ui/cmds.go
@@ -70,6 +70,15 @@ func insertManualEntry(db *sql.DB, taskId int, beginTS time.Time, endTS time.Tim
 	}
 }
 
+func updateTaskLog(db *sql.DB, listIndex int, taskId, taskLogId int, beginTS time.Time, endTS time.Time, comment string, originalSecsSpent int) tea.Cmd {
+	return func() tea.Msg {
+		secsSpent := int(endTS.Sub(beginTS).Seconds())
+		secsDifference := secsSpent - originalSecsSpent
+		err := updateTLInDB(db, taskId, taskLogId, beginTS, endTS, comment, secsDifference)
+		return taskLogUpdatedPostComplMsg{err}
+	}
+}
+
 func fetchActiveTask(db *sql.DB) tea.Cmd {
 	return func() tea.Msg {
 		activeTaskDetails, err := fetchActiveTaskFromDB(db)

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -60,6 +60,7 @@ var (
 `),
 		helpHeaderStyle.Render("Task Logs List View"),
 		helpSectionStyle.Render(`
+    u                                       Update task log
     <ctrl+d>                                Delete task log entry
 `),
 		helpHeaderStyle.Render("Inactive Task List View"),

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -26,13 +26,14 @@ const (
 
 type stateView uint
 
+// TODO: editStartTsView, askForCommentView, and tasklogEntryView can be consolidated into one
 const (
 	activeTaskListView stateView = iota
 	taskLogView
 	inactiveTaskListView
 	editStartTsView
 	askForCommentView
-	manualTasklogEntryView
+	tasklogEntryView
 	taskInputView
 	helpView
 )
@@ -58,8 +59,6 @@ const (
 	entryComment
 )
 
-type tasklogSaveType uint
-
 type recordsType uint
 
 const (
@@ -69,9 +68,12 @@ const (
 	reportStats
 )
 
+type tasklogSaveType uint
+
 const (
 	tasklogInsert tasklogSaveType = iota
-	tasklogUpdate
+	tasklogUpdateBeforeCompl
+	tasklogUpdateAfterCompl
 )
 
 const (

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -21,6 +21,10 @@ type manualTaskLogInserted struct {
 	err    error
 }
 
+type taskLogUpdatedPostComplMsg struct {
+	err error
+}
+
 type tlBeginTSUpdatedMsg struct {
 	beginTS time.Time
 	err     error

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -28,9 +28,6 @@ func (t *task) updateDesc() {
 
 	t.desc = fmt.Sprintf("%s %s", RightPadTrim(lastUpdated, 60, true), timeSpent)
 }
-func (tl *taskLogEntry) updateTitle() {
-	tl.title = Trim(tl.comment, 60)
-}
 
 func (tl *taskLogEntry) updateDesc() {
 	timeSpentStr := humanizeDuration(tl.secsSpent)

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -24,7 +24,6 @@ type taskLogEntry struct {
 	endTs       time.Time
 	secsSpent   int
 	comment     string
-	title       string
 	desc        string
 }
 
@@ -54,7 +53,7 @@ func (t task) FilterValue() string {
 }
 
 func (e taskLogEntry) Title() string {
-	return e.title
+	return e.comment
 }
 
 func (e taskLogEntry) Description() string {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -139,12 +139,12 @@ func (m model) View() string {
 		for i := 0; i < m.terminalHeight-14; i++ {
 			content += "\n"
 		}
-	case manualTasklogEntryView:
+	case tasklogEntryView:
 		var formHeadingText string
 		switch m.tasklogSaveType {
 		case tasklogInsert:
 			formHeadingText = "Adding a manual log entry. Enter the following details."
-		case tasklogUpdate:
+		case tasklogUpdateBeforeCompl, tasklogUpdateAfterCompl:
 			formHeadingText = "Updating log entry. Enter the following details."
 		}
 


### PR DESCRIPTION
- Allow a task log to be updated after its creation
- Don't trim task log comments in the "Task Log View"
