### PR TITLE
feat: allow time tracking via the CLI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,4 +57,4 @@ linters-settings:
       - name: confusing-naming
       - name: unused-receiver
       - name: unhandled-error
-        arguments: ["fmt.Print", "fmt.Printf", "fmt.Fprintf", "fmt.Fprint"]
+        arguments: ["fmt.Print", "fmt.Printf", "fmt.Fprintf", "fmt.Fprint", "fmt.Fprintln"]

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"errors"
+)
+
+var (
+	errCouldntUnmarshalToJSON  = errors.New("couldn't unmarshal data to JSON")
+	errCouldntFetchDataFromDB  = errors.New("couldn't fetch data from hours' DB")
+	errCouldntUpdateDataInDB   = errors.New("couldn't update data in hours' DB")
+	errCouldntParseTaskID      = errors.New("couldn't parse the argument for task ID as an integer")
+	errTaskAlreadyBeingTracked = errors.New("task is already being tracked")
+	errCouldntParseBeginTS     = errors.New("couldn't parse begin timestamp")
+	errCouldntParseEndTS       = errors.New("couldn't parse end timestamp")
+)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,9 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	c "github.com/dhth/hours/internal/common"
 	pers "github.com/dhth/hours/internal/persistence"
@@ -21,6 +23,7 @@ const (
 	defaultDBName     = "hours.db"
 	numDaysThreshold  = 30
 	numTasksThreshold = 20
+	numTasksLimit     = 50
 )
 
 var (
@@ -109,6 +112,10 @@ func NewRootCommand() (*cobra.Command, error) {
 		genNumDays          uint8
 		genNumTasks         uint8
 		genSkipConfirmation bool
+		tasksLimit          uint
+		trackTaskComment    string
+		trackTaskBeginTS    string
+		trackTaskEndTS      string
 	)
 
 	rootCmd := &cobra.Command{
@@ -366,6 +373,130 @@ eg. hours active -t ' {{task}} ({{time}}) '
 		},
 	}
 
+	tasksCmd := &cobra.Command{
+		Use:   "tasks",
+		Short: "List tasks tracked by hours",
+		Args:  cobra.MaximumNArgs(0),
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return renderTasks(db, os.Stdout, tasksLimit)
+		},
+	}
+
+	trackCmd := &cobra.Command{
+		Use:   "track",
+		Short: "Interact with hours' time tracking",
+		Args:  cobra.ExactArgs(0),
+	}
+
+	startTrackCmd := &cobra.Command{
+		Use:   "start <TASK_ID>",
+		Short: "Start tracking time for a task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			taskID, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("%w: %s", errCouldntParseTaskID, err.Error())
+			}
+
+			var comment *string
+			commentTrimmed := strings.TrimSpace(trackTaskComment)
+			if commentTrimmed != "" {
+				comment = &commentTrimmed
+			}
+
+			return startTracking(db, os.Stdout, taskID, comment)
+		},
+	}
+
+	updateTrackCmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update active task log",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(_ *cobra.Command, _ []string) error {
+			var beginTS time.Time
+			var err error
+			if trackTaskBeginTS != "" {
+				beginTS, err = time.ParseInLocation(c.TimeFormat, trackTaskBeginTS, time.Local)
+				if err != nil {
+					return fmt.Errorf("%w: %s", errCouldntParseBeginTS, err.Error())
+				}
+			}
+
+			if beginTS.After(time.Now()) {
+				return c.ErrBeginTsCannotBeInTheFuture
+			}
+
+			var comment *string
+			commentTrimmed := strings.TrimSpace(trackTaskComment)
+			if commentTrimmed != "" {
+				comment = &commentTrimmed
+			}
+
+			return updateTracking(db, os.Stdout, beginTS, comment)
+		},
+	}
+
+	stopTrackCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop active task log",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(_ *cobra.Command, _ []string) error {
+			errs := &c.MultiError{}
+
+			now := time.Now()
+			var beginTS *time.Time
+			if trackTaskBeginTS != "" {
+				ts, err := time.ParseInLocation(c.TimeFormat, trackTaskBeginTS, time.Local)
+				if err != nil {
+					errs.Add(fmt.Errorf("%w: %s", errCouldntParseBeginTS, err.Error()))
+				} else {
+					if ts.After(now) {
+						errs.Add(c.ErrBeginTsCannotBeInTheFuture)
+					} else {
+						beginTS = &ts
+					}
+				}
+			}
+
+			var endTS *time.Time
+			if trackTaskBeginTS != "" {
+				ts, err := time.ParseInLocation(c.TimeFormat, trackTaskEndTS, time.Local)
+				if err != nil {
+					errs.Add(fmt.Errorf("%w: %s", errCouldntParseEndTS, err.Error()))
+				} else {
+					if ts.After(now) {
+						errs.Add(c.ErrEndTsCannotBeInTheFuture)
+					} else {
+						endTS = &ts
+					}
+				}
+			}
+
+			if errs.NumErrors() > 1 {
+				return errs
+			} else if errs.NumErrors() == 1 {
+				return errs.Unwrap()
+			}
+
+			var comment *string
+			commentTrimmed := strings.TrimSpace(trackTaskComment)
+			if commentTrimmed != "" {
+				comment = &commentTrimmed
+			}
+
+			return stopTracking(db, os.Stdout, beginTS, endTS, comment)
+		},
+	}
+
+	activeTrackCmd := &cobra.Command{
+		Use:   "active",
+		Short: "Show details about the active task log",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return renderActiveTLDetails(db, os.Stdout)
+		},
+	}
+
 	var err error
 	userHomeDir, err = os.UserHomeDir()
 	if err != nil {
@@ -391,11 +522,29 @@ eg. hours active -t ' {{task}} ({{time}}) '
 
 	activeCmd.Flags().StringVarP(&activeTemplate, "template", "t", ui.ActiveTaskPlaceholder, "string template to use for outputting active task")
 
+	tasksCmd.Flags().UintVarP(&tasksLimit, "limit", "l", numTasksLimit, "number of tasks to output")
+
+	startTrackCmd.Flags().StringVarP(&trackTaskComment, "comment", "c", "", "task log comment")
+	startTrackCmd.Flags().StringVarP(&trackTaskBeginTS, "begin-ts", "b", "", "task log begin timestamp")
+
+	updateTrackCmd.Flags().StringVarP(&trackTaskComment, "comment", "c", "", "task log comment")
+	updateTrackCmd.Flags().StringVarP(&trackTaskBeginTS, "begin-ts", "b", "", "task log begin timestamp")
+
+	stopTrackCmd.Flags().StringVarP(&trackTaskComment, "comment", "c", "", "task log comment")
+	stopTrackCmd.Flags().StringVarP(&trackTaskBeginTS, "begin-ts", "b", "", "task log begin timestamp")
+	stopTrackCmd.Flags().StringVarP(&trackTaskEndTS, "end-ts", "e", "", "task log end timestamp")
+
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(reportCmd)
 	rootCmd.AddCommand(logCmd)
 	rootCmd.AddCommand(statsCmd)
 	rootCmd.AddCommand(activeCmd)
+	rootCmd.AddCommand(tasksCmd)
+	trackCmd.AddCommand(startTrackCmd)
+	trackCmd.AddCommand(updateTrackCmd)
+	trackCmd.AddCommand(stopTrackCmd)
+	trackCmd.AddCommand(activeTrackCmd)
+	rootCmd.AddCommand(trackCmd)
 
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	pers "github.com/dhth/hours/internal/persistence"
+)
+
+const (
+	tasksLimit = 500
+)
+
+func renderTasks(db *sql.DB, writer io.Writer, limit uint) error {
+	limitToUse := limit
+	if limit > tasksLimit {
+		limitToUse = tasksLimit
+	}
+
+	tasks, err := pers.FetchTasks(db, true, limitToUse)
+	if err != nil {
+		return err
+	}
+
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	result, err := json.MarshalIndent(tasks, "", "  ")
+	if err != nil {
+		return fmt.Errorf("%w: %s", errCouldntUnmarshalToJSON, err.Error())
+	}
+
+	fmt.Fprintln(writer, string(result))
+
+	return nil
+}

--- a/cmd/track.go
+++ b/cmd/track.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	pers "github.com/dhth/hours/internal/persistence"
+)
+
+func renderActiveTLDetails(db *sql.DB, writer io.Writer) error {
+	details, err := pers.FetchActiveTaskDetails(db)
+	if errors.Is(err, pers.ErrNoTaskActive) {
+		return err
+	} else if err != nil {
+		return fmt.Errorf("%w: %w", errCouldntFetchDataFromDB, err)
+	}
+
+	result, err := json.MarshalIndent(details, "", "  ")
+	if err != nil {
+		return fmt.Errorf("%w: %s", errCouldntUnmarshalToJSON, err.Error())
+	}
+
+	fmt.Fprintln(writer, string(result))
+
+	return nil
+}
+
+func startTracking(db *sql.DB, writer io.Writer, taskID int, comment *string) error {
+	details, err := pers.FetchActiveTaskDetails(db)
+	var noTaskActive bool
+	if errors.Is(err, pers.ErrNoTaskActive) {
+		noTaskActive = true
+	} else if err != nil {
+		return fmt.Errorf("%w: %w", errCouldntFetchDataFromDB, err)
+	}
+
+	now := time.Now()
+	switch noTaskActive {
+	case true:
+		_, err := pers.InsertNewTL(db, taskID, now, comment)
+		if err != nil {
+			return fmt.Errorf("%w: %w", errCouldntUpdateDataInDB, err)
+		}
+	case false:
+		if details.TaskID == taskID {
+			return errTaskAlreadyBeingTracked
+		}
+		_, err := pers.QuickSwitchActiveTL(db, taskID, now, comment)
+		if err != nil {
+			return fmt.Errorf("%w: %w", errCouldntUpdateDataInDB, err)
+		}
+	}
+
+	return renderActiveTLDetails(db, writer)
+}
+
+func updateTracking(db *sql.DB, writer io.Writer, beginTS time.Time, comment *string) error {
+	_, err := pers.FetchActiveTaskDetails(db)
+	if errors.Is(err, pers.ErrNoTaskActive) {
+		return err
+	} else if err != nil {
+		return fmt.Errorf("%w: %w", errCouldntFetchDataFromDB, err)
+	}
+
+	err = pers.EditActiveTL(db, beginTS, comment)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errCouldntUpdateDataInDB, err)
+	}
+
+	return renderActiveTLDetails(db, writer)
+}
+
+func stopTracking(db *sql.DB, writer io.Writer, beginTS, endTS *time.Time, comment *string) error {
+	details, err := pers.FetchActiveTaskDetails(db)
+	if errors.Is(err, pers.ErrNoTaskActive) {
+		return err
+	} else if err != nil {
+		return fmt.Errorf("%w: %w", errCouldntFetchDataFromDB, err)
+	}
+
+	var bTS time.Time
+	if beginTS == nil {
+		bTS = details.CurrentLogBeginTS
+	} else {
+		bTS = *beginTS
+	}
+
+	var eTS time.Time
+	if endTS == nil {
+		eTS = time.Now()
+	} else {
+		eTS = *endTS
+	}
+
+	var commentToUse *string
+	if comment == nil {
+		commentToUse = details.CurrentLogComment
+	} else {
+		commentToUse = comment
+	}
+
+	err = pers.FinishActiveTL(db, details.TaskID, bTS, eTS, commentToUse)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errCouldntUpdateDataInDB, err)
+	}
+
+	tlDetails, err := pers.FetchTLByID(db, details.TLID)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errCouldntFetchDataFromDB, err)
+	}
+
+	result, err := json.MarshalIndent(tlDetails, "", "  ")
+	if err != nil {
+		return fmt.Errorf("%w: %s", errCouldntUnmarshalToJSON, err.Error())
+	}
+
+	fmt.Fprintln(writer, string(result))
+
+	return nil
+}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -3,4 +3,5 @@ package common
 const (
 	Author        = "@dhth"
 	RepoIssuesURL = "https://github.com/dhth/hours/issues"
+	TimeFormat    = "2006/01/02 15:04"
 )

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -1,0 +1,63 @@
+package common
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	BeginTsCannotBeInTheFutureMsg = "begin timestamp cannot be in the future"
+	EndTsCannotBeInTheFutureMsg   = "end timestamp cannot be in the future"
+)
+
+var (
+	ErrBeginTsCannotBeInTheFuture = errors.New(BeginTsCannotBeInTheFutureMsg)
+	ErrEndTsCannotBeInTheFuture   = errors.New(EndTsCannotBeInTheFutureMsg)
+)
+
+type MultiError struct {
+	errors []error
+}
+
+func (m *MultiError) Error() string {
+	errorMessages := make([]string, len(m.errors))
+	for i, err := range m.errors {
+		errorMessages[i] = "- " + err.Error()
+	}
+	return "\n" + strings.Join(errorMessages, "\n")
+}
+
+func (m *MultiError) Unwrap() error {
+	if len(m.errors) == 0 {
+		return nil
+	}
+	return m.errors[0]
+}
+
+func (m *MultiError) Is(target error) bool {
+	for _, err := range m.errors {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MultiError) As(target interface{}) bool {
+	for _, err := range m.errors {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MultiError) Add(err error) {
+	if err != nil {
+		m.errors = append(m.errors, err)
+	}
+}
+
+func (m *MultiError) NumErrors() int {
+	return len(m.errors)
+}

--- a/internal/persistence/queries_test.go
+++ b/internal/persistence/queries_test.go
@@ -64,7 +64,7 @@ func TestRepository(t *testing.T) {
 		numSeconds := 60 * 90
 		endTS := time.Now()
 		beginTS := endTS.Add(time.Second * -1 * time.Duration(numSeconds))
-		_, insertErr := InsertNewTL(testDB, taskID, beginTS)
+		_, insertErr := InsertNewTL(testDB, taskID, beginTS, nil)
 		require.NoError(t, insertErr, "failed to insert task log")
 
 		// WHEN
@@ -101,7 +101,7 @@ func TestRepository(t *testing.T) {
 		numSeconds := 60 * 90
 		endTS := time.Now()
 		beginTS := endTS.Add(time.Second * -1 * time.Duration(numSeconds))
-		tlID, insertErr := InsertNewTL(testDB, taskID, beginTS)
+		tlID, insertErr := InsertNewTL(testDB, taskID, beginTS, nil)
 		require.NoError(t, insertErr, "failed to insert task log")
 
 		taskBefore, err := fetchTaskByID(testDB, taskID)
@@ -110,12 +110,12 @@ func TestRepository(t *testing.T) {
 
 		// WHEN
 		comment := testComment
-		err = FinishActiveTL(testDB, tlID, taskID, beginTS, endTS, numSeconds, &comment)
+		err = FinishActiveTL(testDB, taskID, beginTS, endTS, &comment)
 
 		// THEN
 		require.NoError(t, err, "failed to update task log")
 
-		taskLog, err := fetchTLByID(testDB, tlID)
+		taskLog, err := FetchTLByID(testDB, tlID)
 		require.NoError(t, err, "failed to fetch task log")
 
 		taskAfter, err := fetchTaskByID(testDB, taskID)
@@ -138,16 +138,16 @@ func TestRepository(t *testing.T) {
 		numSeconds := 60 * 90
 		endTS := time.Now()
 		beginTS := endTS.Add(time.Second * -1 * time.Duration(numSeconds))
-		tlID, insertErr := InsertNewTL(testDB, taskID, beginTS)
+		tlID, insertErr := InsertNewTL(testDB, taskID, beginTS, nil)
 		require.NoError(t, insertErr, "failed to insert task log")
 
 		// WHEN
-		err = FinishActiveTL(testDB, tlID, taskID, beginTS, endTS, numSeconds, nil)
+		err = FinishActiveTL(testDB, taskID, beginTS, endTS, nil)
 
 		// THEN
 		require.NoError(t, err, "failed to update task log")
 
-		taskLog, err := fetchTLByID(testDB, tlID)
+		taskLog, err := FetchTLByID(testDB, tlID)
 		require.NoError(t, err, "failed to fetch task log")
 
 		assert.Equal(t, numSeconds, taskLog.SecsSpent)
@@ -166,19 +166,19 @@ func TestRepository(t *testing.T) {
 		numSeconds := 60 * 90
 		now := time.Now().Truncate(time.Second)
 		beginTS := now.Add(time.Second * -1 * time.Duration(numSeconds))
-		tlID, insertErr := InsertNewTL(testDB, taskID, beginTS)
+		tlID, insertErr := InsertNewTL(testDB, taskID, beginTS, nil)
 		require.NoError(t, insertErr, "failed to insert task log")
 
 		taskBefore, err := fetchTaskByID(testDB, taskID)
 		require.NoError(t, err, "failed to fetch task")
 
 		// WHEN
-		result, err := QuickSwitchActiveTL(testDB, secondTaskID, now)
+		result, err := QuickSwitchActiveTL(testDB, secondTaskID, now, nil)
 
 		// THEN
 		require.NoError(t, err, "failed to quick switch active task")
 
-		finishedTL, err := fetchTLByID(testDB, tlID)
+		finishedTL, err := FetchTLByID(testDB, tlID)
 		require.NoError(t, err, "failed to fetch last active task log")
 
 		activeTL, err := fetchActiveTLByID(testDB, result.CurrentlyActiveTLID)
@@ -209,7 +209,7 @@ func TestRepository(t *testing.T) {
 		numSeconds := 60 * 90
 		now := time.Now().Truncate(time.Second)
 		beginTS := now.Add(time.Second * -1 * time.Duration(numSeconds))
-		tlID, insertErr := InsertNewTL(testDB, taskID, beginTS)
+		tlID, insertErr := InsertNewTL(testDB, taskID, beginTS, nil)
 		require.NoError(t, insertErr, "failed to insert task log")
 
 		taskBefore, err := fetchTaskByID(testDB, taskID)
@@ -221,12 +221,12 @@ func TestRepository(t *testing.T) {
 		require.NoError(t, err, "failed to update active task log")
 
 		// WHEN
-		result, err := QuickSwitchActiveTL(testDB, secondTaskID, now)
+		result, err := QuickSwitchActiveTL(testDB, secondTaskID, now, nil)
 
 		// THEN
 		require.NoError(t, err, "failed to quick switch active task")
 
-		finishedTL, err := fetchTLByID(testDB, tlID)
+		finishedTL, err := FetchTLByID(testDB, tlID)
 		require.NoError(t, err, "failed to fetch last active task log")
 
 		activeTL, err := fetchActiveTLByID(testDB, result.CurrentlyActiveTLID)
@@ -253,7 +253,7 @@ func TestRepository(t *testing.T) {
 		now := time.Now().Truncate(time.Second)
 
 		// WHEN
-		_, err := QuickSwitchActiveTL(testDB, 1, now)
+		_, err := QuickSwitchActiveTL(testDB, 1, now, nil)
 
 		// THEN
 		require.ErrorIs(t, ErrNoTaskActive, err)
@@ -282,7 +282,7 @@ func TestRepository(t *testing.T) {
 		// THEN
 		require.NoError(t, err, "failed to insert task log")
 
-		taskLog, err := fetchTLByID(testDB, tlID)
+		taskLog, err := FetchTLByID(testDB, tlID)
 		require.NoError(t, err, "failed to fetch task log")
 
 		taskAfter, err := fetchTaskByID(testDB, taskID)
@@ -312,7 +312,7 @@ func TestRepository(t *testing.T) {
 		// THEN
 		require.NoError(t, err, "failed to insert task log")
 
-		taskLog, err := fetchTLByID(testDB, tlID)
+		taskLog, err := FetchTLByID(testDB, tlID)
 		require.NoError(t, err, "failed to fetch task log")
 
 		assert.Equal(t, numSeconds, taskLog.SecsSpent)
@@ -347,7 +347,7 @@ func TestRepository(t *testing.T) {
 		// THEN
 		require.NoError(t, err, "failed to edit saved task log")
 
-		taskLog, err := fetchTLByID(testDB, tlID)
+		taskLog, err := FetchTLByID(testDB, tlID)
 		require.NoError(t, err, "failed to fetch task log")
 
 		taskAfter, err := fetchTaskByID(testDB, taskID)
@@ -388,7 +388,7 @@ func TestRepository(t *testing.T) {
 		// THEN
 		require.NoError(t, err, "failed to edit saved task log")
 
-		taskLog, err := fetchTLByID(testDB, tlID)
+		taskLog, err := FetchTLByID(testDB, tlID)
 		require.NoError(t, err, "failed to fetch task log")
 
 		taskAfter, err := fetchTaskByID(testDB, taskID)
@@ -430,7 +430,7 @@ func TestRepository(t *testing.T) {
 		// THEN
 		require.NoError(t, err, "failed to edit saved task log")
 
-		taskLog, err := fetchTLByID(testDB, tlID)
+		taskLog, err := FetchTLByID(testDB, tlID)
 		require.NoError(t, err, "failed to fetch task log")
 
 		taskAfter, err := fetchTaskByID(testDB, taskID)
@@ -456,7 +456,7 @@ func TestRepository(t *testing.T) {
 		taskBefore, err := fetchTaskByID(testDB, taskID)
 		require.NoError(t, err, "failed to fetch task")
 		numSecondsBefore := taskBefore.SecsSpent
-		taskLog, err := fetchTLByID(testDB, tlID)
+		taskLog, err := FetchTLByID(testDB, tlID)
 		require.NoError(t, err, "failed to fetch task log")
 
 		// WHEN
@@ -613,7 +613,7 @@ func cleanupDB(t *testing.T, testDB *sql.DB) {
 
 type testData struct {
 	tasks    []types.Task
-	taskLogs []types.TaskLogEntry
+	taskLogs []types.TaskLogWithTaskDetails
 }
 
 func getTestData(referenceTS time.Time) testData {
@@ -641,9 +641,9 @@ func getTestData(referenceTS time.Time) testData {
 	commentTask1TL1 := "task 1 tl 1"
 	commentTask1TL2 := "task 1 tl 2"
 	commentTask2TL1 := "task 2 tl 1"
-	taskLogs := []types.TaskLogEntry{
+	taskLogs := []types.TaskLogWithTaskDetails{
 		{
-			ID:        1,
+			TLID:      1,
 			TaskID:    1,
 			BeginTS:   ca.Add(time.Hour * 2),
 			EndTS:     ca.Add(time.Hour * 4),
@@ -651,7 +651,7 @@ func getTestData(referenceTS time.Time) testData {
 			Comment:   &commentTask1TL1,
 		},
 		{
-			ID:        2,
+			TLID:      2,
 			TaskID:    1,
 			BeginTS:   ca.Add(time.Hour * 6),
 			EndTS:     ca.Add(time.Hour * 9),
@@ -659,7 +659,7 @@ func getTestData(referenceTS time.Time) testData {
 			Comment:   &commentTask1TL2,
 		},
 		{
-			ID:        3,
+			TLID:      3,
 			TaskID:    2,
 			BeginTS:   ca.Add(time.Hour * 2),
 			EndTS:     ca.Add(time.Hour * 6),
@@ -684,7 +684,7 @@ VALUES (?, ?, ?, ?, ?, ?)`, task.ID, task.Summary, task.SecsSpent, task.Active, 
 	for _, taskLog := range data.taskLogs {
 		_, err := db.Exec(`
 INSERT INTO task_log (id, task_id, begin_ts, end_ts, secs_spent, comment, active)
-VALUES (?, ?, ?, ?, ?, ?, ?)`, taskLog.ID, taskLog.TaskID, taskLog.BeginTS, taskLog.EndTS, taskLog.SecsSpent, taskLog.Comment, false)
+VALUES (?, ?, ?, ?, ?, ?, ?)`, taskLog.TLID, taskLog.TaskID, taskLog.BeginTS, taskLog.EndTS, taskLog.SecsSpent, taskLog.Comment, false)
 		require.NoError(t, err, "failed to insert data into table \"task_log\": %v", err)
 	}
 }

--- a/internal/types/date_helpers.go
+++ b/internal/types/date_helpers.go
@@ -10,7 +10,6 @@ import (
 const (
 	timePeriodDaysUpperBound = 7
 	TimePeriodWeek           = "week"
-	timeFormat               = "2006/01/02 15:04"
 	timeOnlyFormat           = "15:04"
 	dayFormat                = "Monday"
 	friendlyTimeFormat       = "Mon, 15:04"

--- a/internal/types/date_helpers_test.go
+++ b/internal/types/date_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	c "github.com/dhth/hours/internal/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,8 +82,8 @@ func TestParseDateDuration(t *testing.T) {
 				return
 			}
 
-			startStr := got.Start.Format(timeFormat)
-			endStr := got.End.Format(timeFormat)
+			startStr := got.Start.Format(c.TimeFormat)
+			endStr := got.End.Format(c.TimeFormat)
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedStartStr, startStr)
@@ -93,17 +94,17 @@ func TestParseDateDuration(t *testing.T) {
 }
 
 func TestGetTimePeriod(t *testing.T) {
-	now, err := time.ParseInLocation(timeFormat, "2024/06/20 20:00", time.Local)
+	now, err := time.ParseInLocation(c.TimeFormat, "2024/06/20 20:00", time.Local)
 	if err != nil {
 		t.Fatalf("error setting up the test: time is not valid: %s", err)
 	}
 
-	nowME, err := time.ParseInLocation(timeFormat, "2024/05/31 20:00", time.Local)
+	nowME, err := time.ParseInLocation(c.TimeFormat, "2024/05/31 20:00", time.Local)
 	if err != nil {
 		t.Fatalf("error setting up the test: time is not valid: %s", err)
 	}
 
-	nowMB, err := time.ParseInLocation(timeFormat, "2024/06/01 20:00", time.Local)
+	nowMB, err := time.ParseInLocation(c.TimeFormat, "2024/06/01 20:00", time.Local)
 	if err != nil {
 		t.Fatalf("error setting up the test: time is not valid: %s", err)
 	}
@@ -204,8 +205,8 @@ func TestGetTimePeriod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GetTimePeriod(tt.period, tt.now, tt.fullWeek)
 
-			startStr := got.Start.Format(timeFormat)
-			endStr := got.End.Format(timeFormat)
+			startStr := got.Start.Format(c.TimeFormat)
+			endStr := got.End.Format(c.TimeFormat)
 
 			if tt.err == nil {
 				assert.Equal(t, tt.expectedStartStr, startStr)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -12,27 +12,27 @@ import (
 const emptyCommentIndicator = "∅"
 
 type Task struct {
-	ID             int
-	Summary        string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	TrackingActive bool
-	SecsSpent      int
-	Active         bool
-	ListTitle      string
-	ListDesc       string
+	ID             int       `json:"id"`
+	Summary        string    `json:"summary"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	TrackingActive bool      `json:"tracking_active"`
+	SecsSpent      int       `json:"seconds_spent"`
+	Active         bool      `json:"-"`
+	ListTitle      string    `json:"-"`
+	ListDesc       string    `json:"-"`
 }
 
-type TaskLogEntry struct {
-	ID          int
-	TaskID      int
-	TaskSummary string
-	BeginTS     time.Time
-	EndTS       time.Time
-	SecsSpent   int
-	Comment     *string
-	ListTitle   string
-	ListDesc    string
+type TaskLogWithTaskDetails struct {
+	TaskID      int       `json:"task_id"`
+	TaskSummary string    `json:"task_summary"`
+	TLID        int       `json:"-"`
+	BeginTS     time.Time `json:"begin_ts"`
+	EndTS       time.Time `json:"end_ts"`
+	SecsSpent   int       `json:"seconds_spent"`
+	Comment     *string   `json:"comment"`
+	ListTitle   string    `json:"-"`
+	ListDesc    string    `json:"-"`
 }
 
 type ActiveTaskLogEntry struct {
@@ -44,10 +44,11 @@ type ActiveTaskLogEntry struct {
 }
 
 type ActiveTaskDetails struct {
-	TaskID            int
-	TaskSummary       string
-	CurrentLogBeginTS time.Time
-	CurrentLogComment *string
+	TaskID            int       `json:"task_id"`
+	TaskSummary       string    `json:"task_summary"`
+	TLID              int       `json:"-"`
+	CurrentLogBeginTS time.Time `json:"begin_ts"`
+	CurrentLogComment *string   `json:"comment"`
 }
 
 type TaskReportEntry struct {
@@ -79,11 +80,11 @@ func (t *Task) UpdateListDesc() {
 	t.ListDesc = fmt.Sprintf("%s %s", utils.RightPadTrim(lastUpdated, 60, true), timeSpent)
 }
 
-func (tl *TaskLogEntry) UpdateListTitle() {
+func (tl *TaskLogWithTaskDetails) UpdateListTitle() {
 	tl.ListTitle = utils.TrimWithMoreLinesIndicator(tl.GetComment(), 60)
 }
 
-func (tl *TaskLogEntry) UpdateListDesc() {
+func (tl *TaskLogWithTaskDetails) UpdateListDesc() {
 	timeSpentStr := HumanizeDuration(tl.SecsSpent)
 
 	var timeStr string
@@ -109,7 +110,7 @@ func (tl *TaskLogEntry) UpdateListDesc() {
 	tl.ListDesc = fmt.Sprintf("%s %s", utils.RightPadTrim(tl.TaskSummary, 60, true), timeStr)
 }
 
-func (tl *TaskLogEntry) GetComment() string {
+func (tl *TaskLogWithTaskDetails) GetComment() string {
 	if tl.Comment == nil {
 		return emptyCommentIndicator
 	}
@@ -129,16 +130,16 @@ func (t Task) FilterValue() string {
 	return t.Summary
 }
 
-func (tl TaskLogEntry) Title() string {
+func (tl TaskLogWithTaskDetails) Title() string {
 	return tl.ListTitle
 }
 
-func (tl TaskLogEntry) Description() string {
+func (tl TaskLogWithTaskDetails) Description() string {
 	return tl.ListDesc
 }
 
-func (tl TaskLogEntry) FilterValue() string {
-	return fmt.Sprintf("%d", tl.ID)
+func (tl TaskLogWithTaskDetails) FilterValue() string {
+	return fmt.Sprintf("%d", tl.TLID)
 }
 
 func HumanizeDuration(durationInSecs int) string {

--- a/internal/ui/initial.go
+++ b/internal/ui/initial.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/lipgloss"
+	c "github.com/dhth/hours/internal/common"
 	"github.com/dhth/hours/internal/types"
 )
 
@@ -24,12 +25,12 @@ func InitialModel(db *sql.DB) Model {
 	tLInputs := make([]textinput.Model, 2)
 	tLInputs[entryBeginTS] = textinput.New()
 	tLInputs[entryBeginTS].Placeholder = "09:30"
-	tLInputs[entryBeginTS].CharLimit = len(timeFormat)
+	tLInputs[entryBeginTS].CharLimit = len(c.TimeFormat)
 	tLInputs[entryBeginTS].Width = 30
 
 	tLInputs[entryEndTS] = textinput.New()
 	tLInputs[entryEndTS].Placeholder = "12:30pm"
-	tLInputs[entryEndTS].CharLimit = len(timeFormat)
+	tLInputs[entryEndTS].CharLimit = len(c.TimeFormat)
 	tLInputs[entryEndTS].Width = 30
 
 	tLCommentInput := textarea.New()

--- a/internal/ui/log.go
+++ b/internal/ui/log.go
@@ -10,6 +10,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	c "github.com/dhth/hours/internal/common"
 	pers "github.com/dhth/hours/internal/persistence"
 	"github.com/dhth/hours/internal/types"
 	"github.com/dhth/hours/internal/utils"
@@ -95,7 +96,7 @@ func getTaskLog(db *sql.DB, start, end time.Time, limit int, plain bool) (string
 			data[i] = []string{
 				utils.RightPadTrim(entry.TaskSummary, 20, false),
 				utils.RightPadTrimWithMoreLinesIndicator(entry.GetComment(), 40),
-				fmt.Sprintf("%s  ...  %s", entry.BeginTS.Format(timeFormat), entry.EndTS.Format(timeFormat)),
+				fmt.Sprintf("%s  ...  %s", entry.BeginTS.Format(c.TimeFormat), entry.EndTS.Format(c.TimeFormat)),
 				utils.RightPadTrim(timeSpentStr, logTimeCharsBudget, false),
 			}
 		} else {
@@ -107,7 +108,7 @@ func getTaskLog(db *sql.DB, start, end time.Time, limit int, plain bool) (string
 			data[i] = []string{
 				rowStyle.Render(utils.RightPadTrim(entry.TaskSummary, 20, false)),
 				rowStyle.Render(utils.RightPadTrimWithMoreLinesIndicator(entry.GetComment(), 40)),
-				rowStyle.Render(fmt.Sprintf("%s  ...  %s", entry.BeginTS.Format(timeFormat), entry.EndTS.Format(timeFormat))),
+				rowStyle.Render(fmt.Sprintf("%s  ...  %s", entry.BeginTS.Format(c.TimeFormat), entry.EndTS.Format(c.TimeFormat))),
 				rowStyle.Render(utils.RightPadTrim(timeSpentStr, logTimeCharsBudget, false)),
 			}
 		}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -73,7 +73,6 @@ const (
 )
 
 const (
-	timeFormat         = "2006/01/02 15:04"
 	timeOnlyFormat     = "15:04"
 	dayFormat          = "Monday"
 	friendlyTimeFormat = "Mon, 15:04"

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -9,10 +9,9 @@ import (
 type hideHelpMsg struct{}
 
 type trackingToggledMsg struct {
-	taskID    int
-	finished  bool
-	secsSpent int
-	err       error
+	taskID   int
+	finished bool
+	err      error
 }
 
 type activeTLSwitchedMsg struct {
@@ -56,7 +55,7 @@ type activeTaskFetchedMsg struct {
 }
 
 type tLsFetchedMsg struct {
-	entries       []types.TaskLogEntry
+	entries       []types.TaskLogWithTaskDetails
 	tlIDToFocusOn *int
 	err           error
 }
@@ -78,7 +77,7 @@ type taskActiveStatusUpdatedMsg struct {
 }
 
 type tLDeletedMsg struct {
-	entry *types.TaskLogEntry
+	entry *types.TaskLogWithTaskDetails
 	err   error
 }
 

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -67,7 +67,7 @@ func getReport(db *sql.DB, start time.Time, numDays int, plain bool) (string, er
 	var nextDay time.Time
 
 	var maxEntryForADay int
-	reportData := make(map[int][]types.TaskLogEntry)
+	reportData := make(map[int][]types.TaskLogWithTaskDetails)
 
 	noEntriesFound := true
 	for i := 0; i < numDays; i++ {


### PR DESCRIPTION
Adds the following API via the CLI:

## List tasks

```bash
hours tasks --limit 3
```

```json
[
  {
    "id": 8,
    "summary": "sql",
    "created_at": "2025-01-18T15:22:41.178314+01:00",
    "updated_at": "2025-01-20T00:14:33.732783+01:00",
    "tracking_active": false,
    "seconds_spent": 77336
  },
  {
    "id": 1,
    "summary": "javascript",
    "created_at": "2025-01-18T15:22:41.093522+01:00",
    "updated_at": "2025-01-20T00:09:39.09208+01:00",
    "tracking_active": false,
    "seconds_spent": 86100
  },
  {
    "id": 2,
    "summary": "objective-c",
    "created_at": "2025-01-18T15:22:41.105774+01:00",
    "updated_at": "2025-01-19T23:38:34.912586+01:00",
    "tracking_active": false,
    "seconds_spent": 87978
  }
]
```

## Start tracking

```bash
hours start 8 -c "task comment goes here"
```

```json
{
  "task_id": 8,
  "task_summary": "sql",
  "begin_ts": "2025-01-20T00:20:12.719771+01:00",
  "comment": "task comment goes here"
}
```

## Update tracking

```bash
hours track update -b '2025/01/20 00:10' -c "task comment goes here, updated"
```

```json
{
  "task_id": 8,
  "task_summary": "sql",
  "begin_ts": "2025-01-20T00:10:00+01:00",
  "comment": "task comment goes here, updated"
}
```

## End tracking

```bash
hours track stop -b '2025/01/20 00:12' -e '2025/01/19 23:18' -c "task comment goes here, updated, again"
```

```json
{
  "task_id": 8,
  "task_summary": "sql",
  "begin_ts": "2025-01-20T00:12:00+01:00",
  "end_ts": "2025-01-19T23:18:00+01:00",
  "seconds_spent": -3240,
  "comment": "task comment goes here, updated, again"
}
```

## Quick switch tracking

Given, a task being tracked:

```bash
hours start 8 -c "task comment goes here"
# after a while
hours track start 2 -c "quick switched"
```

```json
{
  "task_id": 2,
  "task_summary": "objective-c",
  "begin_ts": "2025-01-20T00:23:11.275523+01:00",
  "comment": "quick switched"
}
```
