### PR TITLE
chore(ci): update golangci-lint to 1.64

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,4 +28,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.63
+          version: v1.64

--- a/internal/ui/cmds.go
+++ b/internal/ui/cmds.go
@@ -43,18 +43,16 @@ LIMIT 1
 			_, err = pers.InsertNewTL(db, taskID, beginTs)
 			if err != nil {
 				return trackingToggledMsg{err: err}
-			} else {
-				return trackingToggledMsg{taskID: taskID}
 			}
+			return trackingToggledMsg{taskID: taskID}
 
 		default:
 			secsSpent := int(endTs.Sub(beginTs).Seconds())
 			err := pers.FinishActiveTL(db, activeTaskLogID, activeTaskID, beginTs, endTs, secsSpent, comment)
 			if err != nil {
 				return trackingToggledMsg{err: err}
-			} else {
-				return trackingToggledMsg{taskID: taskID, finished: true, secsSpent: secsSpent}
 			}
+			return trackingToggledMsg{taskID: taskID, finished: true, secsSpent: secsSpent}
 		}
 	}
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -430,12 +430,11 @@ func (m recordsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 			m.quitting = true
 			return m, tea.Quit
-		} else {
-			m.start = msg.start
-			m.end = msg.end
-			m.report = msg.report
-			m.busy = false
 		}
+		m.start = msg.start
+		m.end = msg.end
+		m.report = msg.report
+		m.busy = false
 	}
 	return m, tea.Batch(cmds...)
 }


### PR DESCRIPTION
Bump `golangci-lint` to 1.64 which from my testing locally seems to solve the problem in #51.