### PR TITLE
lower min terminal width needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Removed limit on range limit for stats and log
+- Removed date range limit for stats and log commands
 - Missing end date in date range implies today (eg. 2025/08/12...)
 - "today" can be used in date range (eg. 2025/08/12...today)
-- Improved TUI navigation: (Esc/q) now function from more panes, returning the
-    user to previous panes in a predictable manner
+- Improved TUI navigation: esc/q now function in more panes, returning the user
+    to previous panes in a predictable manner
 - User messages in the TUI remain visible for a while
+- Minimum terminal width needed brought down to 80 characters (from 96)
 
 ## [v0.5.0] - Feb 22, 2025
 

--- a/internal/ui/__snapshots__/TestInsufficientDimensionsView_1.snap
+++ b/internal/ui/__snapshots__/TestInsufficientDimensionsView_1.snap
@@ -1,8 +1,9 @@
 
-    Terminal size too small:
-      Width = 50 Height = 20
+  Terminal size too small:
+    Width = 50 Height = 20
 
-    Minimum dimensions needed:
-      Width = 96 Height = 32
+  Minimum dimensions needed:
+    Width = 80 Height = 32
 
-    Press (q/<ctrl+c>/<esc> to exit)
+  Press q/<ctrl+c>/<esc>
+    to exit

--- a/internal/ui/__snapshots__/TestTerminalWidthResizingWorks_1.snap
+++ b/internal/ui/__snapshots__/TestTerminalWidthResizingWorks_1.snap
@@ -1,0 +1,32 @@
+                                                                                
+   Task Logs (last 50)                                                          
+                                                                                
+  3 entries                                                                     
+                                                                                
+│ Test work on task                                                             
+│ Implement feature A                                          06:30  ...  08…  
+                                                                                
+  Test work on task                                                             
+  Fix bug in module B                                          06:30  ...  08…  
+                                                                                
+  Test work on task                                                             
+  Implement feature A                                          06:30  ...  08…  
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+ hours   Press ? for help                                                       

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -41,12 +41,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	if m.message.framesLeft > 0 {
-		m.message.framesLeft--
-	}
+	if m.activeView != insufficientDimensionsView {
+		if m.message.framesLeft > 0 {
+			m.message.framesLeft--
+		}
 
-	if m.message.framesLeft == 0 {
-		m.message.value = ""
+		if m.message.framesLeft == 0 {
+			m.message.value = ""
+		}
 	}
 
 	keyMsg, keyMsgOK := msg.(tea.KeyMsg)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -14,7 +14,7 @@ import (
 const (
 	taskLogEntryViewHeading = "Task Log Entry"
 	minHeightNeeded         = 32
-	minWidthNeeded          = 96
+	minWidthNeeded          = 80
 	tlWarningThresholdSecs  = 8 * 60 * 60
 )
 
@@ -272,13 +272,14 @@ func (m Model) View() string {
 		}
 	case insufficientDimensionsView:
 		return fmt.Sprintf(`
-    Terminal size too small:
-      Width = %d Height = %d
+  Terminal size too small:
+    Width = %d Height = %d
 
-    Minimum dimensions needed:
-      Width = %d Height = %d
+  Minimum dimensions needed:
+    Width = %d Height = %d
 
-    Press (q/<ctrl+c>/<esc> to exit)
+  Press q/<ctrl+c>/<esc>
+    to exit
 `, m.terminalWidth, m.terminalHeight, minWidthNeeded, minHeightNeeded)
 	}
 

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -407,6 +407,31 @@ func TestTaskListViewDebugMode(t *testing.T) {
 	snaps.MatchStandaloneSnapshot(t, result)
 }
 
+func TestTerminalWidthResizingWorks(t *testing.T) {
+	// GIVEN
+	m := createTestModel()
+	m.activeView = taskLogView
+
+	entry1 := createTestTaskLogEntry(1, 1, "Implement feature A", m.timeProvider)
+	entry2 := createTestTaskLogEntry(2, 2, "Fix bug in module B", m.timeProvider)
+	entry3 := createTestTaskLogEntry(3, 1, "Implement feature A", m.timeProvider)
+
+	items := []list.Item{entry1, entry2, entry3}
+	m.taskLogList.SetItems(items)
+
+	// WHEN
+	msg := tea.WindowSizeMsg{
+		Width:  minWidthNeeded,
+		Height: minHeightNeeded,
+	}
+	m.handleWindowResizing(msg)
+
+	result := m.View()
+
+	// THEN
+	snaps.MatchStandaloneSnapshot(t, result)
+}
+
 func createTestModel() Model {
 	theme := DefaultTheme()
 	style := NewStyle(theme)
@@ -415,7 +440,7 @@ func createTestModel() Model {
 	m := InitialModel(nil, style, testTimeProvider, false, logFramesConfig{})
 
 	msg := tea.WindowSizeMsg{
-		Width:  minWidthNeeded,
+		Width:  96,
 		Height: minHeightNeeded,
 	}
 	m.handleWindowResizing(msg)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Reduced minimum terminal width to 80 characters (from 96).
- Bug Fixes
  - Improved behavior when the terminal is too small, with clearer exit instructions and more consistent message handling in that view.
- Documentation
  - Clarified changelog entries: specified “date range limit for stats and log commands” and updated key references to “esc/q.”
- Tests
  - Added a test to validate terminal width resizing behavior for logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->