### PR TITLE
add workflow for virus scanning binaries

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,7 +2,6 @@ name: scan
 
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   virus-total:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a CI workflow to build release binaries and scan them with VirusTotal.
  - Workflow runs on manual dispatch (not automatically on pull requests).
  - Go toolchain version is derived from the project version file in CI.
  - Builds binaries in snapshot mode before scanning.
  - Configured rate-limited VirusTotal scanning of the built artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->