### PR TITLE
update go toolchain to 1.25.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dhth/hours
 
-go 1.25.0
+go 1.25.2
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded Go runtime from 1.25.0 to 1.25.2 to include the latest patch updates.
  * Improves stability and security with no changes to functionality or UI.
  * Enhances build reliability and compatibility with upstream tooling.
  * No user action required; existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->