### PR TITLE
feat: added export functionality

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -150,6 +150,7 @@ func NewRootCommand() (*cobra.Command, error) {
 		recordsInteractive  bool
 		recordsOutputPlain  bool
 		taskStatusStr       string
+		outputFormatStr     string
 		activeTemplate      string
 		genNumDays          uint8
 		genNumTasks         uint8
@@ -346,11 +347,18 @@ Accepts an argument, which can be one of the following:
 
 Note: If a task log continues past midnight in your local timezone, it
 will be reported on the day it ends.
+
+Use --format to export the report as json or csv instead of the default table.
 `, reportNumDaysThreshold),
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: preRun,
 		RunE: func(_ *cobra.Command, args []string) error {
 			taskStatus, err := types.ParseTaskStatus(taskStatusStr)
+			if err != nil {
+				return err
+			}
+
+			outputFormat, err := types.ParseOutputFormat(outputFormatStr)
 			if err != nil {
 				return err
 			}
@@ -378,7 +386,7 @@ will be reported on the day it ends.
 				return err
 			}
 
-			return ui.RenderReport(db, style, os.Stdout, recordsOutputPlain, dateRange, period, taskStatus, reportAgg, recordsInteractive)
+			return ui.RenderReport(db, style, os.Stdout, recordsOutputPlain, dateRange, period, taskStatus, reportAgg, recordsInteractive, outputFormat)
 		},
 	}
 
@@ -398,11 +406,18 @@ Accepts an argument, which can be one of the following:
 
 Note: If a task log continues past midnight in your local timezone, it'll
 appear in the log for the day it ends.
+
+Use --format to export logs as json or csv instead of the default table.
 `,
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: preRun,
 		RunE: func(_ *cobra.Command, args []string) error {
 			taskStatus, err := types.ParseTaskStatus(taskStatusStr)
+			if err != nil {
+				return err
+			}
+
+			outputFormat, err := types.ParseOutputFormat(outputFormatStr)
 			if err != nil {
 				return err
 			}
@@ -424,7 +439,7 @@ appear in the log for the day it ends.
 				return err
 			}
 
-			return ui.RenderTaskLog(db, style, os.Stdout, recordsOutputPlain, dateRange, period, taskStatus, recordsInteractive)
+			return ui.RenderTaskLog(db, style, os.Stdout, recordsOutputPlain, dateRange, period, taskStatus, recordsInteractive, outputFormat)
 		},
 	}
 
@@ -445,11 +460,18 @@ Accepts an argument, which can be one of the following:
 
 Note: If a task log continues past midnight in your local timezone, it'll
 be considered in the stats for the day it ends.
+
+Use --format to export stats as json or csv instead of the default table.
 `,
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: preRun,
 		RunE: func(_ *cobra.Command, args []string) error {
 			taskStatus, err := types.ParseTaskStatus(taskStatusStr)
+			if err != nil {
+				return err
+			}
+
+			outputFormat, err := types.ParseOutputFormat(outputFormatStr)
 			if err != nil {
 				return err
 			}
@@ -480,7 +502,7 @@ be considered in the stats for the day it ends.
 				dateRange = &dr
 			}
 
-			return ui.RenderStats(db, style, os.Stdout, recordsOutputPlain, dateRange, period, taskStatus, recordsInteractive)
+			return ui.RenderStats(db, style, os.Stdout, recordsOutputPlain, dateRange, period, taskStatus, recordsInteractive, outputFormat)
 		},
 	}
 
@@ -634,18 +656,21 @@ eg. hours active -t ' {{task}} ({{time}}) '
 	reportCmd.Flags().BoolVarP(&reportAgg, "agg", "a", false, "whether to aggregate data by task for each day in report")
 	reportCmd.Flags().BoolVarP(&recordsInteractive, "interactive", "i", false, "whether to view report interactively")
 	reportCmd.Flags().BoolVarP(&recordsOutputPlain, "plain", "p", false, "whether to output report without any formatting")
+	reportCmd.Flags().StringVarP(&outputFormatStr, "format", "f", types.OFValuePlain, fmt.Sprintf("output format [possible values: %q]", types.ValidOutputFormatValues))
 	reportCmd.Flags().StringVarP(&dbPath, "dbpath", "d", defaultDBPath, "location of hours' database file")
 	reportCmd.Flags().StringVarP(&taskStatusStr, "task-status", "s", "any", fmt.Sprintf("only show data for tasks with this status [possible values: %q]", types.ValidTaskStatusValues))
 	reportCmd.Flags().StringVarP(&themeName, "theme", "t", defaultThemeName, `UI theme to use (run "hours themes list" for allowed values)`)
 
 	logCmd.Flags().BoolVarP(&recordsOutputPlain, "plain", "p", false, "whether to output logs without any formatting")
 	logCmd.Flags().BoolVarP(&recordsInteractive, "interactive", "i", false, "whether to view logs interactively")
+	logCmd.Flags().StringVarP(&outputFormatStr, "format", "f", types.OFValuePlain, fmt.Sprintf("output format [possible values: %q]", types.ValidOutputFormatValues))
 	logCmd.Flags().StringVarP(&dbPath, "dbpath", "d", defaultDBPath, "location of hours' database file")
 	logCmd.Flags().StringVarP(&taskStatusStr, "task-status", "s", "any", fmt.Sprintf("only show data for tasks with this status [possible values: %q]", types.ValidTaskStatusValues))
 	logCmd.Flags().StringVarP(&themeName, "theme", "t", defaultThemeName, `UI theme to use (run "hours themes list" for allowed values)`)
 
 	statsCmd.Flags().BoolVarP(&recordsOutputPlain, "plain", "p", false, "whether to output stats without any formatting")
 	statsCmd.Flags().BoolVarP(&recordsInteractive, "interactive", "i", false, "whether to view stats interactively")
+	statsCmd.Flags().StringVarP(&outputFormatStr, "format", "f", types.OFValuePlain, fmt.Sprintf("output format [possible values: %q]", types.ValidOutputFormatValues))
 	statsCmd.Flags().StringVarP(&dbPath, "dbpath", "d", defaultDBPath, "location of hours' database file")
 	statsCmd.Flags().StringVarP(&taskStatusStr, "task-status", "s", "any", fmt.Sprintf("only show data for tasks with this status [possible values: %q]", types.ValidTaskStatusValues))
 	statsCmd.Flags().StringVarP(&themeName, "theme", "t", defaultThemeName, `UI theme to use (run "hours themes list" for allowed values)`)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,7 @@ var (
 	errCouldntMarshalTheme       = errors.New("couldn't marshal theme")
 	errNowInvalid                = errors.New("invalid HOURS_NOW")
 	errGenSeedInvalid            = errors.New("invalid HOURS_GEN_SEED")
+	errPlainFormatConflict       = errors.New("plain and format flags cannot be used together")
 
 	msgReportIssue = fmt.Sprintf("This isn't supposed to happen; let %s know about this error via \n%s.", c.Author, c.RepoIssuesURL)
 )
@@ -134,6 +135,14 @@ func getStyle(themeName string, themesDir string) (ui.Style, error) {
 	}
 
 	return ui.NewStyle(thm), nil
+}
+
+func validateOutputOptions(plain bool, format types.OutputFormat) error {
+	if plain && format != types.OutputFormatPlain {
+		return fmt.Errorf("%w with output format %q", errPlainFormatConflict, format)
+	}
+
+	return nil
 }
 
 func NewRootCommand() (*cobra.Command, error) {
@@ -363,6 +372,10 @@ Use --format to export the report as json or csv instead of the default table.
 				return err
 			}
 
+			if err := validateOutputOptions(recordsOutputPlain, outputFormat); err != nil {
+				return err
+			}
+
 			var period string
 			if len(args) == 0 {
 				period = "3d"
@@ -422,6 +435,10 @@ Use --format to export logs as json or csv instead of the default table.
 				return err
 			}
 
+			if err := validateOutputOptions(recordsOutputPlain, outputFormat); err != nil {
+				return err
+			}
+
 			var period string
 			if len(args) == 0 {
 				period = "today"
@@ -473,6 +490,10 @@ Use --format to export stats as json or csv instead of the default table.
 
 			outputFormat, err := types.ParseOutputFormat(outputFormatStr)
 			if err != nil {
+				return err
+			}
+
+			if err := validateOutputOptions(recordsOutputPlain, outputFormat); err != nil {
 				return err
 			}
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -12,7 +12,10 @@ import (
 
 const emptyCommentIndicator = "∅"
 
-var ErrIncorrectTaskStatusProvided = errors.New("incorrect task status provided")
+var (
+	ErrIncorrectTaskStatusProvided   = errors.New("incorrect task status provided")
+	ErrIncorrectOutputFormatProvided = errors.New("incorrect output format provided")
+)
 
 type Task struct {
 	ID             int
@@ -227,6 +230,48 @@ func ParseTaskStatus(value string) (TaskStatus, error) {
 }
 
 var ValidTaskStatusValues = []string{TSValueActive, TSValueInactive, TSValueAny}
+
+type OutputFormat uint8
+
+const (
+	OFValuePlain = "plain"
+	OFValueJSON  = "json"
+	OFValueCSV   = "csv"
+)
+
+const (
+	OutputFormatPlain OutputFormat = iota
+	OutputFormatJSON
+	OutputFormatCSV
+)
+
+func ParseOutputFormat(value string) (OutputFormat, error) {
+	switch value {
+	case OFValuePlain:
+		return OutputFormatPlain, nil
+	case OFValueJSON:
+		return OutputFormatJSON, nil
+	case OFValueCSV:
+		return OutputFormatCSV, nil
+	default:
+		return OutputFormatPlain, ErrIncorrectOutputFormatProvided
+	}
+}
+
+func (f OutputFormat) String() string {
+	switch f {
+	case OutputFormatPlain:
+		return OFValuePlain
+	case OutputFormatJSON:
+		return OFValueJSON
+	case OutputFormatCSV:
+		return OFValueCSV
+	default:
+		return OFValuePlain
+	}
+}
+
+var ValidOutputFormatValues = []string{OFValuePlain, OFValueJSON, OFValueCSV}
 
 type DateRange struct {
 	Start   time.Time

--- a/internal/ui/export.go
+++ b/internal/ui/export.go
@@ -1,0 +1,325 @@
+package ui
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/dhth/hours/internal/types"
+)
+
+type exportLogEntry struct {
+	TaskID    int    `json:"taskId"`
+	Task      string `json:"task"`
+	BeginTS   string `json:"beginTs"`
+	EndTS     string `json:"endTs"`
+	SecsSpent int    `json:"secsSpent"`
+	TimeSpent string `json:"timeSpent"`
+	Comment   string `json:"comment"`
+}
+
+type exportReportDay struct {
+	Date           string           `json:"date"`
+	TotalSecsSpent int              `json:"totalSecsSpent"`
+	TotalTimeSpent string           `json:"totalTimeSpent"`
+	Entries        []exportLogEntry `json:"entries"`
+}
+
+type exportReportJSON struct {
+	Days []exportReportDay `json:"days"`
+}
+
+type exportAggEntry struct {
+	TaskID     int    `json:"taskId"`
+	Task       string `json:"task"`
+	NumEntries int    `json:"numEntries"`
+	SecsSpent  int    `json:"secsSpent"`
+	TimeSpent  string `json:"timeSpent"`
+}
+
+type exportReportAggDay struct {
+	Date           string           `json:"date"`
+	TotalSecsSpent int              `json:"totalSecsSpent"`
+	TotalTimeSpent string           `json:"totalTimeSpent"`
+	Entries        []exportAggEntry `json:"entries"`
+}
+
+type exportReportAggJSON struct {
+	Days []exportReportAggDay `json:"days"`
+}
+
+type exportLogJSON struct {
+	Entries []exportLogEntry `json:"entries"`
+}
+
+type exportStatsEntry struct {
+	TaskID     int    `json:"taskId"`
+	Task       string `json:"task"`
+	NumEntries int    `json:"numEntries"`
+	SecsSpent  int    `json:"secsSpent"`
+	TimeSpent  string `json:"timeSpent"`
+}
+
+type exportStatsJSON struct {
+	Entries []exportStatsEntry `json:"entries"`
+}
+
+func exportComment(comment *string) string {
+	if comment == nil {
+		return ""
+	}
+
+	return *comment
+}
+
+func toExportLogEntry(entry types.TaskLogEntry) exportLogEntry {
+	return exportLogEntry{
+		TaskID:    entry.TaskID,
+		Task:      entry.TaskSummary,
+		BeginTS:   entry.BeginTS.Format(time.RFC3339),
+		EndTS:     entry.EndTS.Format(time.RFC3339),
+		SecsSpent: entry.SecsSpent,
+		TimeSpent: types.HumanizeDuration(entry.SecsSpent),
+		Comment:   exportComment(entry.Comment),
+	}
+}
+
+func toExportAggEntry(entry types.TaskReportEntry) exportAggEntry {
+	return exportAggEntry{
+		TaskID:     entry.TaskID,
+		Task:       entry.TaskSummary,
+		NumEntries: entry.NumEntries,
+		SecsSpent:  entry.SecsSpent,
+		TimeSpent:  types.HumanizeDuration(entry.SecsSpent),
+	}
+}
+
+func toExportStatsEntry(entry types.TaskReportEntry) exportStatsEntry {
+	return exportStatsEntry{
+		TaskID:     entry.TaskID,
+		Task:       entry.TaskSummary,
+		NumEntries: entry.NumEntries,
+		SecsSpent:  entry.SecsSpent,
+		TimeSpent:  types.HumanizeDuration(entry.SecsSpent),
+	}
+}
+
+func writeJSON(writer io.Writer, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintln(writer, string(data))
+	return err
+}
+
+func writeReportJSON(
+	writer io.Writer,
+	start time.Time,
+	numDays int,
+	reportData map[int][]types.TaskLogEntry,
+) error {
+	days := make([]exportReportDay, 0, numDays)
+	day := start
+	for i := range numDays {
+		entries := reportData[i]
+		totalSecs := 0
+		exportEntries := make([]exportLogEntry, 0, len(entries))
+		for _, entry := range entries {
+			totalSecs += entry.SecsSpent
+			exportEntries = append(exportEntries, toExportLogEntry(entry))
+		}
+
+		days = append(days, exportReportDay{
+			Date:           day.Format(dateFormat),
+			TotalSecsSpent: totalSecs,
+			TotalTimeSpent: types.HumanizeDuration(totalSecs),
+			Entries:        exportEntries,
+		})
+		day = day.AddDate(0, 0, 1)
+	}
+
+	return writeJSON(writer, exportReportJSON{Days: days})
+}
+
+func writeReportAggJSON(
+	writer io.Writer,
+	start time.Time,
+	numDays int,
+	reportData map[int][]types.TaskReportEntry,
+) error {
+	days := make([]exportReportAggDay, 0, numDays)
+	day := start
+	for i := range numDays {
+		entries := reportData[i]
+		totalSecs := 0
+		exportEntries := make([]exportAggEntry, 0, len(entries))
+		for _, entry := range entries {
+			totalSecs += entry.SecsSpent
+			exportEntries = append(exportEntries, toExportAggEntry(entry))
+		}
+
+		days = append(days, exportReportAggDay{
+			Date:           day.Format(dateFormat),
+			TotalSecsSpent: totalSecs,
+			TotalTimeSpent: types.HumanizeDuration(totalSecs),
+			Entries:        exportEntries,
+		})
+		day = day.AddDate(0, 0, 1)
+	}
+
+	return writeJSON(writer, exportReportAggJSON{Days: days})
+}
+
+func writeReportCSV(
+	writer io.Writer,
+	start time.Time,
+	numDays int,
+	reportData map[int][]types.TaskLogEntry,
+) error {
+	w := csv.NewWriter(writer)
+	defer w.Flush()
+
+	if err := w.Write([]string{"date", "taskId", "task", "beginTs", "endTs", "secsSpent", "timeSpent", "comment"}); err != nil {
+		return err
+	}
+
+	day := start
+	for i := range numDays {
+		date := day.Format(dateFormat)
+		for _, entry := range reportData[i] {
+			exportEntry := toExportLogEntry(entry)
+			if err := w.Write([]string{
+				date,
+				strconv.Itoa(exportEntry.TaskID),
+				exportEntry.Task,
+				exportEntry.BeginTS,
+				exportEntry.EndTS,
+				strconv.Itoa(exportEntry.SecsSpent),
+				exportEntry.TimeSpent,
+				exportEntry.Comment,
+			}); err != nil {
+				return err
+			}
+		}
+		day = day.AddDate(0, 0, 1)
+	}
+
+	return w.Error()
+}
+
+func writeReportAggCSVRows(
+	w *csv.Writer,
+	start time.Time,
+	numDays int,
+	reportData map[int][]types.TaskReportEntry,
+) error {
+	day := start
+	for i := range numDays {
+		date := day.Format(dateFormat)
+		for _, entry := range reportData[i] {
+			exportEntry := toExportAggEntry(entry)
+			if err := w.Write([]string{
+				date,
+				strconv.Itoa(exportEntry.TaskID),
+				exportEntry.Task,
+				strconv.Itoa(exportEntry.NumEntries),
+				strconv.Itoa(exportEntry.SecsSpent),
+				exportEntry.TimeSpent,
+			}); err != nil {
+				return err
+			}
+		}
+		day = day.AddDate(0, 0, 1)
+	}
+
+	return w.Error()
+}
+
+func writeReportAggCSV(
+	writer io.Writer,
+	start time.Time,
+	numDays int,
+	reportData map[int][]types.TaskReportEntry,
+) error {
+	w := csv.NewWriter(writer)
+	defer w.Flush()
+
+	if err := w.Write([]string{"date", "taskId", "task", "numEntries", "secsSpent", "timeSpent"}); err != nil {
+		return err
+	}
+
+	return writeReportAggCSVRows(w, start, numDays, reportData)
+}
+
+func writeLogJSON(writer io.Writer, entries []types.TaskLogEntry) error {
+	exportEntries := make([]exportLogEntry, 0, len(entries))
+	for _, entry := range entries {
+		exportEntries = append(exportEntries, toExportLogEntry(entry))
+	}
+
+	return writeJSON(writer, exportLogJSON{Entries: exportEntries})
+}
+
+func writeLogCSV(writer io.Writer, entries []types.TaskLogEntry) error {
+	w := csv.NewWriter(writer)
+	defer w.Flush()
+
+	if err := w.Write([]string{"taskId", "task", "beginTs", "endTs", "secsSpent", "timeSpent", "comment"}); err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		exportEntry := toExportLogEntry(entry)
+		if err := w.Write([]string{
+			strconv.Itoa(exportEntry.TaskID),
+			exportEntry.Task,
+			exportEntry.BeginTS,
+			exportEntry.EndTS,
+			strconv.Itoa(exportEntry.SecsSpent),
+			exportEntry.TimeSpent,
+			exportEntry.Comment,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return w.Error()
+}
+
+func writeStatsJSON(writer io.Writer, entries []types.TaskReportEntry) error {
+	exportEntries := make([]exportStatsEntry, 0, len(entries))
+	for _, entry := range entries {
+		exportEntries = append(exportEntries, toExportStatsEntry(entry))
+	}
+
+	return writeJSON(writer, exportStatsJSON{Entries: exportEntries})
+}
+
+func writeStatsCSV(writer io.Writer, entries []types.TaskReportEntry) error {
+	w := csv.NewWriter(writer)
+	defer w.Flush()
+
+	if err := w.Write([]string{"taskId", "task", "numEntries", "secsSpent", "timeSpent"}); err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		exportEntry := toExportStatsEntry(entry)
+		if err := w.Write([]string{
+			strconv.Itoa(exportEntry.TaskID),
+			exportEntry.Task,
+			strconv.Itoa(exportEntry.NumEntries),
+			strconv.Itoa(exportEntry.SecsSpent),
+			exportEntry.TimeSpent,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return w.Error()
+}

--- a/internal/ui/export.go
+++ b/internal/ui/export.go
@@ -55,13 +55,7 @@ type exportLogJSON struct {
 	Entries []exportLogEntry `json:"entries"`
 }
 
-type exportStatsEntry struct {
-	TaskID     int    `json:"taskId"`
-	Task       string `json:"task"`
-	NumEntries int    `json:"numEntries"`
-	SecsSpent  int    `json:"secsSpent"`
-	TimeSpent  string `json:"timeSpent"`
-}
+type exportStatsEntry = exportAggEntry
 
 type exportStatsJSON struct {
 	Entries []exportStatsEntry `json:"entries"`
@@ -89,16 +83,6 @@ func toExportLogEntry(entry types.TaskLogEntry) exportLogEntry {
 
 func toExportAggEntry(entry types.TaskReportEntry) exportAggEntry {
 	return exportAggEntry{
-		TaskID:     entry.TaskID,
-		Task:       entry.TaskSummary,
-		NumEntries: entry.NumEntries,
-		SecsSpent:  entry.SecsSpent,
-		TimeSpent:  types.HumanizeDuration(entry.SecsSpent),
-	}
-}
-
-func toExportStatsEntry(entry types.TaskReportEntry) exportStatsEntry {
-	return exportStatsEntry{
 		TaskID:     entry.TaskID,
 		Task:       entry.TaskSummary,
 		NumEntries: entry.NumEntries,
@@ -182,7 +166,6 @@ func writeReportCSV(
 	reportData map[int][]types.TaskLogEntry,
 ) error {
 	w := csv.NewWriter(writer)
-	defer w.Flush()
 
 	if err := w.Write([]string{"date", "taskId", "task", "beginTs", "endTs", "secsSpent", "timeSpent", "comment"}); err != nil {
 		return err
@@ -209,6 +192,7 @@ func writeReportCSV(
 		day = day.AddDate(0, 0, 1)
 	}
 
+	w.Flush()
 	return w.Error()
 }
 
@@ -237,7 +221,7 @@ func writeReportAggCSVRows(
 		day = day.AddDate(0, 0, 1)
 	}
 
-	return w.Error()
+	return nil
 }
 
 func writeReportAggCSV(
@@ -247,13 +231,17 @@ func writeReportAggCSV(
 	reportData map[int][]types.TaskReportEntry,
 ) error {
 	w := csv.NewWriter(writer)
-	defer w.Flush()
 
 	if err := w.Write([]string{"date", "taskId", "task", "numEntries", "secsSpent", "timeSpent"}); err != nil {
 		return err
 	}
 
-	return writeReportAggCSVRows(w, start, numDays, reportData)
+	if err := writeReportAggCSVRows(w, start, numDays, reportData); err != nil {
+		return err
+	}
+
+	w.Flush()
+	return w.Error()
 }
 
 func writeLogJSON(writer io.Writer, entries []types.TaskLogEntry) error {
@@ -267,7 +255,6 @@ func writeLogJSON(writer io.Writer, entries []types.TaskLogEntry) error {
 
 func writeLogCSV(writer io.Writer, entries []types.TaskLogEntry) error {
 	w := csv.NewWriter(writer)
-	defer w.Flush()
 
 	if err := w.Write([]string{"taskId", "task", "beginTs", "endTs", "secsSpent", "timeSpent", "comment"}); err != nil {
 		return err
@@ -288,13 +275,14 @@ func writeLogCSV(writer io.Writer, entries []types.TaskLogEntry) error {
 		}
 	}
 
+	w.Flush()
 	return w.Error()
 }
 
 func writeStatsJSON(writer io.Writer, entries []types.TaskReportEntry) error {
 	exportEntries := make([]exportStatsEntry, 0, len(entries))
 	for _, entry := range entries {
-		exportEntries = append(exportEntries, toExportStatsEntry(entry))
+		exportEntries = append(exportEntries, toExportAggEntry(entry))
 	}
 
 	return writeJSON(writer, exportStatsJSON{Entries: exportEntries})
@@ -302,14 +290,13 @@ func writeStatsJSON(writer io.Writer, entries []types.TaskReportEntry) error {
 
 func writeStatsCSV(writer io.Writer, entries []types.TaskReportEntry) error {
 	w := csv.NewWriter(writer)
-	defer w.Flush()
 
 	if err := w.Write([]string{"taskId", "task", "numEntries", "secsSpent", "timeSpent"}); err != nil {
 		return err
 	}
 
 	for _, entry := range entries {
-		exportEntry := toExportStatsEntry(entry)
+		exportEntry := toExportAggEntry(entry)
 		if err := w.Write([]string{
 			strconv.Itoa(exportEntry.TaskID),
 			exportEntry.Task,
@@ -321,5 +308,6 @@ func writeStatsCSV(writer io.Writer, entries []types.TaskReportEntry) error {
 		}
 	}
 
+	w.Flush()
 	return w.Error()
 }

--- a/internal/ui/log.go
+++ b/internal/ui/log.go
@@ -34,9 +34,30 @@ func RenderTaskLog(db *sql.DB,
 	period string,
 	taskStatus types.TaskStatus,
 	interactive bool,
+	format types.OutputFormat,
 ) error {
+	if interactive && format != types.OutputFormatPlain {
+		return fmt.Errorf("%w with output format %q", errInteractiveModeNotApplicable, format)
+	}
+
 	if interactive && dateRange.NumDays > interactiveLogDayLimit {
 		return fmt.Errorf("%w (limited to %d day); use non-interactive mode to see logs for a larger time period", errInteractiveModeNotApplicable, interactiveLogDayLimit)
+	}
+
+	if format != types.OutputFormatPlain {
+		entries, err := collectLogData(db, dateRange.Start, dateRange.End, taskStatus)
+		if err != nil {
+			return fmt.Errorf("%w: %s", errCouldntGenerateLogs, err.Error())
+		}
+
+		switch format {
+		case types.OutputFormatJSON:
+			return writeLogJSON(writer, entries)
+		case types.OutputFormatCSV:
+			return writeLogCSV(writer, entries)
+		default:
+			return types.ErrIncorrectOutputFormatProvided
+		}
 	}
 
 	log, err := getTaskLog(db, style, dateRange.Start, dateRange.End, taskStatus, logLimit, plain)
@@ -64,6 +85,15 @@ func RenderTaskLog(db *sql.DB,
 		fmt.Fprint(writer, log)
 	}
 	return nil
+}
+
+func collectLogData(
+	db *sql.DB,
+	start,
+	end time.Time,
+	taskStatus types.TaskStatus,
+) ([]types.TaskLogEntry, error) {
+	return pers.FetchTLEntriesBetweenTS(db, start, end, taskStatus, logLimit)
 }
 
 func getTaskLog(db *sql.DB,

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -33,7 +33,16 @@ func RenderReport(db *sql.DB,
 	taskStatus types.TaskStatus,
 	agg bool,
 	interactive bool,
+	format types.OutputFormat,
 ) error {
+	if interactive && format != types.OutputFormatPlain {
+		return fmt.Errorf("%w with output format %q", errInteractiveModeNotApplicable, format)
+	}
+
+	if format != types.OutputFormatPlain {
+		return renderReportExport(db, writer, dateRange, taskStatus, agg, format)
+	}
+
 	var report string
 	var analyticsType recordsKind
 	var err error
@@ -71,29 +80,106 @@ func RenderReport(db *sql.DB,
 	return nil
 }
 
-func getReport(db *sql.DB, style Style, start time.Time, numDays int, taskStatus types.TaskStatus, plain bool) (string, error) {
+func renderReportExport(
+	db *sql.DB,
+	writer io.Writer,
+	dateRange types.DateRange,
+	taskStatus types.TaskStatus,
+	agg bool,
+	format types.OutputFormat,
+) error {
+	if agg {
+		reportData, err := collectReportAggData(db, dateRange.Start, dateRange.NumDays, taskStatus)
+		if err != nil {
+			return fmt.Errorf("%w: %s", errCouldntGenerateReport, err.Error())
+		}
+
+		switch format {
+		case types.OutputFormatJSON:
+			return writeReportAggJSON(writer, dateRange.Start, dateRange.NumDays, reportData)
+		case types.OutputFormatCSV:
+			return writeReportAggCSV(writer, dateRange.Start, dateRange.NumDays, reportData)
+		default:
+			return types.ErrIncorrectOutputFormatProvided
+		}
+	}
+
+	reportData, err := collectReportData(db, dateRange.Start, dateRange.NumDays, taskStatus)
+	if err != nil {
+		return fmt.Errorf("%w: %s", errCouldntGenerateReport, err.Error())
+	}
+
+	switch format {
+	case types.OutputFormatJSON:
+		return writeReportJSON(writer, dateRange.Start, dateRange.NumDays, reportData)
+	case types.OutputFormatCSV:
+		return writeReportCSV(writer, dateRange.Start, dateRange.NumDays, reportData)
+	default:
+		return types.ErrIncorrectOutputFormatProvided
+	}
+}
+
+func collectReportData(
+	db *sql.DB,
+	start time.Time,
+	numDays int,
+	taskStatus types.TaskStatus,
+) (map[int][]types.TaskLogEntry, error) {
 	day := start
-	var nextDay time.Time
+	reportData := make(map[int][]types.TaskLogEntry, numDays)
 
-	var maxEntryForADay int
-	reportData := make(map[int][]types.TaskLogEntry)
-
-	noEntriesFound := true
 	for i := range numDays {
-		nextDay = day.AddDate(0, 0, 1)
+		nextDay := day.AddDate(0, 0, 1)
 		taskLogEntries, err := pers.FetchTLEntriesBetweenTS(db, day, nextDay, taskStatus, 100)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		if noEntriesFound && len(taskLogEntries) > 0 {
+
+		reportData[i] = taskLogEntries
+		day = nextDay
+	}
+
+	return reportData, nil
+}
+
+func collectReportAggData(
+	db *sql.DB,
+	start time.Time,
+	numDays int,
+	taskStatus types.TaskStatus,
+) (map[int][]types.TaskReportEntry, error) {
+	day := start
+	reportData := make(map[int][]types.TaskReportEntry, numDays)
+
+	for i := range numDays {
+		nextDay := day.AddDate(0, 0, 1)
+		taskReportEntries, err := pers.FetchReportBetweenTS(db, day, nextDay, taskStatus, 100)
+		if err != nil {
+			return nil, err
+		}
+
+		reportData[i] = taskReportEntries
+		day = nextDay
+	}
+
+	return reportData, nil
+}
+
+func getReport(db *sql.DB, style Style, start time.Time, numDays int, taskStatus types.TaskStatus, plain bool) (string, error) {
+	reportData, err := collectReportData(db, start, numDays, taskStatus)
+	if err != nil {
+		return "", err
+	}
+
+	var maxEntryForADay int
+	noEntriesFound := true
+	for i := range numDays {
+		if noEntriesFound && len(reportData[i]) > 0 {
 			noEntriesFound = false
 		}
 
-		day = nextDay
-		reportData[i] = taskLogEntries
-
-		if len(taskLogEntries) > maxEntryForADay {
-			maxEntryForADay = len(taskLogEntries)
+		if len(reportData[i]) > maxEntryForADay {
+			maxEntryForADay = len(reportData[i])
 		}
 	}
 
@@ -172,7 +258,7 @@ func getReport(db *sql.DB, style Style, start time.Time, numDays int, taskStatus
 
 	headersValues := make([]string, numDays)
 
-	day = start
+	day := start
 	counter := 0
 
 	for counter < numDays {
@@ -234,27 +320,20 @@ func getReportAgg(db *sql.DB,
 	plain bool) (string,
 	error,
 ) {
-	day := start
-	var nextDay time.Time
+	reportData, err := collectReportAggData(db, start, numDays, taskStatus)
+	if err != nil {
+		return "", err
+	}
 
 	var maxEntryForADay int
-	reportData := make(map[int][]types.TaskReportEntry)
-
 	noEntriesFound := true
 	for i := range numDays {
-		nextDay = day.AddDate(0, 0, 1)
-		taskLogEntries, err := pers.FetchReportBetweenTS(db, day, nextDay, taskStatus, 100)
-		if err != nil {
-			return "", err
-		}
-		if noEntriesFound && len(taskLogEntries) > 0 {
+		if noEntriesFound && len(reportData[i]) > 0 {
 			noEntriesFound = false
 		}
 
-		day = nextDay
-		reportData[i] = taskLogEntries
-		if len(taskLogEntries) > maxEntryForADay {
-			maxEntryForADay = len(taskLogEntries)
+		if len(reportData[i]) > maxEntryForADay {
+			maxEntryForADay = len(reportData[i])
 		}
 	}
 
@@ -331,7 +410,7 @@ func getReportAgg(db *sql.DB,
 
 	headersValues := make([]string, numDays)
 
-	day = start
+	day := start
 	counter := 0
 
 	for counter < numDays {

--- a/internal/ui/stats.go
+++ b/internal/ui/stats.go
@@ -32,13 +32,34 @@ func RenderStats(db *sql.DB,
 	period string,
 	taskStatus types.TaskStatus,
 	interactive bool,
+	format types.OutputFormat,
 ) error {
-	var stats string
-	var err error
+	if interactive && format != types.OutputFormatPlain {
+		return fmt.Errorf("%w with output format %q", errInteractiveModeNotApplicable, format)
+	}
 
 	if interactive && dateRange == nil {
 		return fmt.Errorf("%w when period=all", errInteractiveModeNotApplicable)
 	}
+
+	if format != types.OutputFormatPlain {
+		entries, err := collectStatsData(db, dateRange, taskStatus)
+		if err != nil {
+			return fmt.Errorf("%w: %s", errCouldntGenerateStats, err.Error())
+		}
+
+		switch format {
+		case types.OutputFormatJSON:
+			return writeStatsJSON(writer, entries)
+		case types.OutputFormatCSV:
+			return writeStatsCSV(writer, entries)
+		default:
+			return types.ErrIncorrectOutputFormatProvided
+		}
+	}
+
+	var stats string
+	var err error
 
 	if dateRange == nil {
 		stats, err = getStats(db, style, dateRange, taskStatus, plain)
@@ -75,6 +96,18 @@ func RenderStats(db *sql.DB,
 		fmt.Fprint(writer, stats)
 	}
 	return nil
+}
+
+func collectStatsData(
+	db *sql.DB,
+	dateRange *types.DateRange,
+	taskStatus types.TaskStatus,
+) ([]types.TaskReportEntry, error) {
+	if dateRange == nil {
+		return pers.FetchStats(db, taskStatus, statsLogEntriesLimit)
+	}
+
+	return pers.FetchStatsBetweenTS(db, dateRange.Start, dateRange.End, taskStatus, statsLogEntriesLimit)
 }
 
 func getStats(db *sql.DB,

--- a/tests/cli/__snapshots__/TestExportFormatErrors_log_interactive_json_1.snap
+++ b/tests/cli/__snapshots__/TestExportFormatErrors_log_interactive_json_1.snap
@@ -1,0 +1,7 @@
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Error: interactive mode is not applicable with output format "json"
+

--- a/tests/cli/__snapshots__/TestExportFormatErrors_report_incorrect_format_1.snap
+++ b/tests/cli/__snapshots__/TestExportFormatErrors_report_incorrect_format_1.snap
@@ -1,0 +1,7 @@
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Error: incorrect output format provided
+

--- a/tests/cli/__snapshots__/TestExportFormatErrors_report_interactive_json_1.snap
+++ b/tests/cli/__snapshots__/TestExportFormatErrors_report_interactive_json_1.snap
@@ -1,0 +1,7 @@
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Error: interactive mode is not applicable with output format "json"
+

--- a/tests/cli/__snapshots__/TestExportFormatErrors_report_plain_json_1.snap
+++ b/tests/cli/__snapshots__/TestExportFormatErrors_report_plain_json_1.snap
@@ -1,0 +1,7 @@
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Error: plain and format flags cannot be used together with output format "json"
+

--- a/tests/cli/__snapshots__/TestExportFormatErrors_stats_interactive_json_1.snap
+++ b/tests/cli/__snapshots__/TestExportFormatErrors_stats_interactive_json_1.snap
@@ -1,0 +1,7 @@
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Error: interactive mode is not applicable with output format "json"
+

--- a/tests/cli/__snapshots__/TestLogExport_csv_3d_1.snap
+++ b/tests/cli/__snapshots__/TestLogExport_csv_3d_1.snap
@@ -1,0 +1,62 @@
+success: true
+exit_code: 0
+----- stdout -----
+taskId,task,beginTs,endTs,secsSpent,timeSpent,comment
+1,haskell,2025-10-22T00:35:05Z,2025-10-22T02:01:05Z,5160,1h 26m,
+8,ocaml,2025-10-22T12:08:04Z,2025-10-22T12:52:04Z,2640,44m,design deployment
+10,c++,2025-10-22T14:54:01Z,2025-10-22T15:36:01Z,2520,42m,configure configuration
+3,clojure,2025-10-22T15:09:08Z,2025-10-22T15:57:08Z,2880,48m,"optimize log
+
+This is a sample task log comment. The comment can be used to record
+additional information for a task log.
+
+You can include:
+- Detailed steps taken during the task
+- Observations and notes
+- Any issues encountered and how they were resolved
+- Future actions or follow-ups required
+- References to related tasks or documents
+
+Use this section to ensure all relevant details are captured for each task,
+providing a comprehensive log that can be referred to later."
+6,swift,2025-10-22T20:07:19Z,2025-10-22T21:16:19Z,4140,1h 9m,
+6,swift,2025-10-22T20:58:08Z,2025-10-22T21:43:08Z,2700,45m,
+8,ocaml,2025-10-23T01:19:04Z,2025-10-23T02:00:04Z,2460,41m,
+4,typescript,2025-10-23T03:32:16Z,2025-10-23T04:21:16Z,2940,49m,implement tests
+3,clojure,2025-10-23T07:16:05Z,2025-10-23T08:04:05Z,2880,48m,
+2,clojure,2025-10-23T10:17:20Z,2025-10-23T11:19:20Z,3720,1h 2m,
+6,swift,2025-10-23T14:08:30Z,2025-10-23T15:09:30Z,3660,1h 1m,"design api
+
+This is a sample task log comment. The comment can be used to record
+additional information for a task log.
+
+You can include:
+- Detailed steps taken during the task
+- Observations and notes
+- Any issues encountered and how they were resolved
+- Future actions or follow-ups required
+- References to related tasks or documents
+
+Use this section to ensure all relevant details are captured for each task,
+providing a comprehensive log that can be referred to later."
+4,typescript,2025-10-23T16:32:15Z,2025-10-23T17:27:15Z,3300,55m,
+7,.net,2025-10-23T21:30:49Z,2025-10-23T22:12:49Z,2520,42m,build function
+5,rust,2025-10-23T22:27:14Z,2025-10-23T23:42:14Z,4500,1h 15m,update interface
+3,clojure,2025-10-24T07:27:40Z,2025-10-24T08:12:40Z,2700,45m,"write report
+
+This is a sample task log comment. The comment can be used to record
+additional information for a task log.
+
+You can include:
+- Detailed steps taken during the task
+- Observations and notes
+- Any issues encountered and how they were resolved
+- Future actions or follow-ups required
+- References to related tasks or documents
+
+Use this section to ensure all relevant details are captured for each task,
+providing a comprehensive log that can be referred to later."
+3,clojure,2025-10-24T08:37:55Z,2025-10-24T09:27:55Z,3000,50m,
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestLogExport_csv_today_1.snap
+++ b/tests/cli/__snapshots__/TestLogExport_csv_today_1.snap
@@ -1,0 +1,22 @@
+success: true
+exit_code: 0
+----- stdout -----
+taskId,task,beginTs,endTs,secsSpent,timeSpent,comment
+3,clojure,2025-10-24T07:27:40Z,2025-10-24T08:12:40Z,2700,45m,"write report
+
+This is a sample task log comment. The comment can be used to record
+additional information for a task log.
+
+You can include:
+- Detailed steps taken during the task
+- Observations and notes
+- Any issues encountered and how they were resolved
+- Future actions or follow-ups required
+- References to related tasks or documents
+
+Use this section to ensure all relevant details are captured for each task,
+providing a comprehensive log that can be referred to later."
+3,clojure,2025-10-24T08:37:55Z,2025-10-24T09:27:55Z,3000,50m,
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestLogExport_json_3d_1.snap
+++ b/tests/cli/__snapshots__/TestLogExport_json_3d_1.snap
@@ -1,0 +1,154 @@
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "entries": [
+    {
+      "taskId": 1,
+      "task": "haskell",
+      "beginTs": "2025-10-22T00:35:05Z",
+      "endTs": "2025-10-22T02:01:05Z",
+      "secsSpent": 5160,
+      "timeSpent": "1h 26m",
+      "comment": ""
+    },
+    {
+      "taskId": 8,
+      "task": "ocaml",
+      "beginTs": "2025-10-22T12:08:04Z",
+      "endTs": "2025-10-22T12:52:04Z",
+      "secsSpent": 2640,
+      "timeSpent": "44m",
+      "comment": "design deployment"
+    },
+    {
+      "taskId": 10,
+      "task": "c++",
+      "beginTs": "2025-10-22T14:54:01Z",
+      "endTs": "2025-10-22T15:36:01Z",
+      "secsSpent": 2520,
+      "timeSpent": "42m",
+      "comment": "configure configuration"
+    },
+    {
+      "taskId": 3,
+      "task": "clojure",
+      "beginTs": "2025-10-22T15:09:08Z",
+      "endTs": "2025-10-22T15:57:08Z",
+      "secsSpent": 2880,
+      "timeSpent": "48m",
+      "comment": "optimize log\n\nThis is a sample task log comment. The comment can be used to record\nadditional information for a task log.\n\nYou can include:\n- Detailed steps taken during the task\n- Observations and notes\n- Any issues encountered and how they were resolved\n- Future actions or follow-ups required\n- References to related tasks or documents\n\nUse this section to ensure all relevant details are captured for each task,\nproviding a comprehensive log that can be referred to later."
+    },
+    {
+      "taskId": 6,
+      "task": "swift",
+      "beginTs": "2025-10-22T20:07:19Z",
+      "endTs": "2025-10-22T21:16:19Z",
+      "secsSpent": 4140,
+      "timeSpent": "1h 9m",
+      "comment": ""
+    },
+    {
+      "taskId": 6,
+      "task": "swift",
+      "beginTs": "2025-10-22T20:58:08Z",
+      "endTs": "2025-10-22T21:43:08Z",
+      "secsSpent": 2700,
+      "timeSpent": "45m",
+      "comment": ""
+    },
+    {
+      "taskId": 8,
+      "task": "ocaml",
+      "beginTs": "2025-10-23T01:19:04Z",
+      "endTs": "2025-10-23T02:00:04Z",
+      "secsSpent": 2460,
+      "timeSpent": "41m",
+      "comment": ""
+    },
+    {
+      "taskId": 4,
+      "task": "typescript",
+      "beginTs": "2025-10-23T03:32:16Z",
+      "endTs": "2025-10-23T04:21:16Z",
+      "secsSpent": 2940,
+      "timeSpent": "49m",
+      "comment": "implement tests"
+    },
+    {
+      "taskId": 3,
+      "task": "clojure",
+      "beginTs": "2025-10-23T07:16:05Z",
+      "endTs": "2025-10-23T08:04:05Z",
+      "secsSpent": 2880,
+      "timeSpent": "48m",
+      "comment": ""
+    },
+    {
+      "taskId": 2,
+      "task": "clojure",
+      "beginTs": "2025-10-23T10:17:20Z",
+      "endTs": "2025-10-23T11:19:20Z",
+      "secsSpent": 3720,
+      "timeSpent": "1h 2m",
+      "comment": ""
+    },
+    {
+      "taskId": 6,
+      "task": "swift",
+      "beginTs": "2025-10-23T14:08:30Z",
+      "endTs": "2025-10-23T15:09:30Z",
+      "secsSpent": 3660,
+      "timeSpent": "1h 1m",
+      "comment": "design api\n\nThis is a sample task log comment. The comment can be used to record\nadditional information for a task log.\n\nYou can include:\n- Detailed steps taken during the task\n- Observations and notes\n- Any issues encountered and how they were resolved\n- Future actions or follow-ups required\n- References to related tasks or documents\n\nUse this section to ensure all relevant details are captured for each task,\nproviding a comprehensive log that can be referred to later."
+    },
+    {
+      "taskId": 4,
+      "task": "typescript",
+      "beginTs": "2025-10-23T16:32:15Z",
+      "endTs": "2025-10-23T17:27:15Z",
+      "secsSpent": 3300,
+      "timeSpent": "55m",
+      "comment": ""
+    },
+    {
+      "taskId": 7,
+      "task": ".net",
+      "beginTs": "2025-10-23T21:30:49Z",
+      "endTs": "2025-10-23T22:12:49Z",
+      "secsSpent": 2520,
+      "timeSpent": "42m",
+      "comment": "build function"
+    },
+    {
+      "taskId": 5,
+      "task": "rust",
+      "beginTs": "2025-10-23T22:27:14Z",
+      "endTs": "2025-10-23T23:42:14Z",
+      "secsSpent": 4500,
+      "timeSpent": "1h 15m",
+      "comment": "update interface"
+    },
+    {
+      "taskId": 3,
+      "task": "clojure",
+      "beginTs": "2025-10-24T07:27:40Z",
+      "endTs": "2025-10-24T08:12:40Z",
+      "secsSpent": 2700,
+      "timeSpent": "45m",
+      "comment": "write report\n\nThis is a sample task log comment. The comment can be used to record\nadditional information for a task log.\n\nYou can include:\n- Detailed steps taken during the task\n- Observations and notes\n- Any issues encountered and how they were resolved\n- Future actions or follow-ups required\n- References to related tasks or documents\n\nUse this section to ensure all relevant details are captured for each task,\nproviding a comprehensive log that can be referred to later."
+    },
+    {
+      "taskId": 3,
+      "task": "clojure",
+      "beginTs": "2025-10-24T08:37:55Z",
+      "endTs": "2025-10-24T09:27:55Z",
+      "secsSpent": 3000,
+      "timeSpent": "50m",
+      "comment": ""
+    }
+  ]
+}
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestLogExport_json_today_1.snap
+++ b/tests/cli/__snapshots__/TestLogExport_json_today_1.snap
@@ -1,0 +1,28 @@
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "entries": [
+    {
+      "taskId": 3,
+      "task": "clojure",
+      "beginTs": "2025-10-24T07:27:40Z",
+      "endTs": "2025-10-24T08:12:40Z",
+      "secsSpent": 2700,
+      "timeSpent": "45m",
+      "comment": "write report\n\nThis is a sample task log comment. The comment can be used to record\nadditional information for a task log.\n\nYou can include:\n- Detailed steps taken during the task\n- Observations and notes\n- Any issues encountered and how they were resolved\n- Future actions or follow-ups required\n- References to related tasks or documents\n\nUse this section to ensure all relevant details are captured for each task,\nproviding a comprehensive log that can be referred to later."
+    },
+    {
+      "taskId": 3,
+      "task": "clojure",
+      "beginTs": "2025-10-24T08:37:55Z",
+      "endTs": "2025-10-24T09:27:55Z",
+      "secsSpent": 3000,
+      "timeSpent": "50m",
+      "comment": ""
+    }
+  ]
+}
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestReportExport_csv_3d_1.snap
+++ b/tests/cli/__snapshots__/TestReportExport_csv_3d_1.snap
@@ -1,0 +1,62 @@
+success: true
+exit_code: 0
+----- stdout -----
+date,taskId,task,beginTs,endTs,secsSpent,timeSpent,comment
+2025/10/22,1,haskell,2025-10-22T00:35:05Z,2025-10-22T02:01:05Z,5160,1h 26m,
+2025/10/22,8,ocaml,2025-10-22T12:08:04Z,2025-10-22T12:52:04Z,2640,44m,design deployment
+2025/10/22,10,c++,2025-10-22T14:54:01Z,2025-10-22T15:36:01Z,2520,42m,configure configuration
+2025/10/22,3,clojure,2025-10-22T15:09:08Z,2025-10-22T15:57:08Z,2880,48m,"optimize log
+
+This is a sample task log comment. The comment can be used to record
+additional information for a task log.
+
+You can include:
+- Detailed steps taken during the task
+- Observations and notes
+- Any issues encountered and how they were resolved
+- Future actions or follow-ups required
+- References to related tasks or documents
+
+Use this section to ensure all relevant details are captured for each task,
+providing a comprehensive log that can be referred to later."
+2025/10/22,6,swift,2025-10-22T20:07:19Z,2025-10-22T21:16:19Z,4140,1h 9m,
+2025/10/22,6,swift,2025-10-22T20:58:08Z,2025-10-22T21:43:08Z,2700,45m,
+2025/10/23,8,ocaml,2025-10-23T01:19:04Z,2025-10-23T02:00:04Z,2460,41m,
+2025/10/23,4,typescript,2025-10-23T03:32:16Z,2025-10-23T04:21:16Z,2940,49m,implement tests
+2025/10/23,3,clojure,2025-10-23T07:16:05Z,2025-10-23T08:04:05Z,2880,48m,
+2025/10/23,2,clojure,2025-10-23T10:17:20Z,2025-10-23T11:19:20Z,3720,1h 2m,
+2025/10/23,6,swift,2025-10-23T14:08:30Z,2025-10-23T15:09:30Z,3660,1h 1m,"design api
+
+This is a sample task log comment. The comment can be used to record
+additional information for a task log.
+
+You can include:
+- Detailed steps taken during the task
+- Observations and notes
+- Any issues encountered and how they were resolved
+- Future actions or follow-ups required
+- References to related tasks or documents
+
+Use this section to ensure all relevant details are captured for each task,
+providing a comprehensive log that can be referred to later."
+2025/10/23,4,typescript,2025-10-23T16:32:15Z,2025-10-23T17:27:15Z,3300,55m,
+2025/10/23,7,.net,2025-10-23T21:30:49Z,2025-10-23T22:12:49Z,2520,42m,build function
+2025/10/23,5,rust,2025-10-23T22:27:14Z,2025-10-23T23:42:14Z,4500,1h 15m,update interface
+2025/10/24,3,clojure,2025-10-24T07:27:40Z,2025-10-24T08:12:40Z,2700,45m,"write report
+
+This is a sample task log comment. The comment can be used to record
+additional information for a task log.
+
+You can include:
+- Detailed steps taken during the task
+- Observations and notes
+- Any issues encountered and how they were resolved
+- Future actions or follow-ups required
+- References to related tasks or documents
+
+Use this section to ensure all relevant details are captured for each task,
+providing a comprehensive log that can be referred to later."
+2025/10/24,3,clojure,2025-10-24T08:37:55Z,2025-10-24T09:27:55Z,3000,50m,
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestReportExport_csv_agg_today_1.snap
+++ b/tests/cli/__snapshots__/TestReportExport_csv_agg_today_1.snap
@@ -1,0 +1,8 @@
+success: true
+exit_code: 0
+----- stdout -----
+date,taskId,task,numEntries,secsSpent,timeSpent
+2025/10/24,3,clojure,2,5700,1h 35m
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestReportExport_csv_today_1.snap
+++ b/tests/cli/__snapshots__/TestReportExport_csv_today_1.snap
@@ -1,0 +1,22 @@
+success: true
+exit_code: 0
+----- stdout -----
+date,taskId,task,beginTs,endTs,secsSpent,timeSpent,comment
+2025/10/24,3,clojure,2025-10-24T07:27:40Z,2025-10-24T08:12:40Z,2700,45m,"write report
+
+This is a sample task log comment. The comment can be used to record
+additional information for a task log.
+
+You can include:
+- Detailed steps taken during the task
+- Observations and notes
+- Any issues encountered and how they were resolved
+- Future actions or follow-ups required
+- References to related tasks or documents
+
+Use this section to ensure all relevant details are captured for each task,
+providing a comprehensive log that can be referred to later."
+2025/10/24,3,clojure,2025-10-24T08:37:55Z,2025-10-24T09:27:55Z,3000,50m,
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestReportExport_json_3d_1.snap
+++ b/tests/cli/__snapshots__/TestReportExport_json_3d_1.snap
@@ -1,0 +1,175 @@
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "days": [
+    {
+      "date": "2025/10/22",
+      "totalSecsSpent": 20040,
+      "totalTimeSpent": "5h 34m",
+      "entries": [
+        {
+          "taskId": 1,
+          "task": "haskell",
+          "beginTs": "2025-10-22T00:35:05Z",
+          "endTs": "2025-10-22T02:01:05Z",
+          "secsSpent": 5160,
+          "timeSpent": "1h 26m",
+          "comment": ""
+        },
+        {
+          "taskId": 8,
+          "task": "ocaml",
+          "beginTs": "2025-10-22T12:08:04Z",
+          "endTs": "2025-10-22T12:52:04Z",
+          "secsSpent": 2640,
+          "timeSpent": "44m",
+          "comment": "design deployment"
+        },
+        {
+          "taskId": 10,
+          "task": "c++",
+          "beginTs": "2025-10-22T14:54:01Z",
+          "endTs": "2025-10-22T15:36:01Z",
+          "secsSpent": 2520,
+          "timeSpent": "42m",
+          "comment": "configure configuration"
+        },
+        {
+          "taskId": 3,
+          "task": "clojure",
+          "beginTs": "2025-10-22T15:09:08Z",
+          "endTs": "2025-10-22T15:57:08Z",
+          "secsSpent": 2880,
+          "timeSpent": "48m",
+          "comment": "optimize log\n\nThis is a sample task log comment. The comment can be used to record\nadditional information for a task log.\n\nYou can include:\n- Detailed steps taken during the task\n- Observations and notes\n- Any issues encountered and how they were resolved\n- Future actions or follow-ups required\n- References to related tasks or documents\n\nUse this section to ensure all relevant details are captured for each task,\nproviding a comprehensive log that can be referred to later."
+        },
+        {
+          "taskId": 6,
+          "task": "swift",
+          "beginTs": "2025-10-22T20:07:19Z",
+          "endTs": "2025-10-22T21:16:19Z",
+          "secsSpent": 4140,
+          "timeSpent": "1h 9m",
+          "comment": ""
+        },
+        {
+          "taskId": 6,
+          "task": "swift",
+          "beginTs": "2025-10-22T20:58:08Z",
+          "endTs": "2025-10-22T21:43:08Z",
+          "secsSpent": 2700,
+          "timeSpent": "45m",
+          "comment": ""
+        }
+      ]
+    },
+    {
+      "date": "2025/10/23",
+      "totalSecsSpent": 25980,
+      "totalTimeSpent": "7h 13m",
+      "entries": [
+        {
+          "taskId": 8,
+          "task": "ocaml",
+          "beginTs": "2025-10-23T01:19:04Z",
+          "endTs": "2025-10-23T02:00:04Z",
+          "secsSpent": 2460,
+          "timeSpent": "41m",
+          "comment": ""
+        },
+        {
+          "taskId": 4,
+          "task": "typescript",
+          "beginTs": "2025-10-23T03:32:16Z",
+          "endTs": "2025-10-23T04:21:16Z",
+          "secsSpent": 2940,
+          "timeSpent": "49m",
+          "comment": "implement tests"
+        },
+        {
+          "taskId": 3,
+          "task": "clojure",
+          "beginTs": "2025-10-23T07:16:05Z",
+          "endTs": "2025-10-23T08:04:05Z",
+          "secsSpent": 2880,
+          "timeSpent": "48m",
+          "comment": ""
+        },
+        {
+          "taskId": 2,
+          "task": "clojure",
+          "beginTs": "2025-10-23T10:17:20Z",
+          "endTs": "2025-10-23T11:19:20Z",
+          "secsSpent": 3720,
+          "timeSpent": "1h 2m",
+          "comment": ""
+        },
+        {
+          "taskId": 6,
+          "task": "swift",
+          "beginTs": "2025-10-23T14:08:30Z",
+          "endTs": "2025-10-23T15:09:30Z",
+          "secsSpent": 3660,
+          "timeSpent": "1h 1m",
+          "comment": "design api\n\nThis is a sample task log comment. The comment can be used to record\nadditional information for a task log.\n\nYou can include:\n- Detailed steps taken during the task\n- Observations and notes\n- Any issues encountered and how they were resolved\n- Future actions or follow-ups required\n- References to related tasks or documents\n\nUse this section to ensure all relevant details are captured for each task,\nproviding a comprehensive log that can be referred to later."
+        },
+        {
+          "taskId": 4,
+          "task": "typescript",
+          "beginTs": "2025-10-23T16:32:15Z",
+          "endTs": "2025-10-23T17:27:15Z",
+          "secsSpent": 3300,
+          "timeSpent": "55m",
+          "comment": ""
+        },
+        {
+          "taskId": 7,
+          "task": ".net",
+          "beginTs": "2025-10-23T21:30:49Z",
+          "endTs": "2025-10-23T22:12:49Z",
+          "secsSpent": 2520,
+          "timeSpent": "42m",
+          "comment": "build function"
+        },
+        {
+          "taskId": 5,
+          "task": "rust",
+          "beginTs": "2025-10-23T22:27:14Z",
+          "endTs": "2025-10-23T23:42:14Z",
+          "secsSpent": 4500,
+          "timeSpent": "1h 15m",
+          "comment": "update interface"
+        }
+      ]
+    },
+    {
+      "date": "2025/10/24",
+      "totalSecsSpent": 5700,
+      "totalTimeSpent": "1h 35m",
+      "entries": [
+        {
+          "taskId": 3,
+          "task": "clojure",
+          "beginTs": "2025-10-24T07:27:40Z",
+          "endTs": "2025-10-24T08:12:40Z",
+          "secsSpent": 2700,
+          "timeSpent": "45m",
+          "comment": "write report\n\nThis is a sample task log comment. The comment can be used to record\nadditional information for a task log.\n\nYou can include:\n- Detailed steps taken during the task\n- Observations and notes\n- Any issues encountered and how they were resolved\n- Future actions or follow-ups required\n- References to related tasks or documents\n\nUse this section to ensure all relevant details are captured for each task,\nproviding a comprehensive log that can be referred to later."
+        },
+        {
+          "taskId": 3,
+          "task": "clojure",
+          "beginTs": "2025-10-24T08:37:55Z",
+          "endTs": "2025-10-24T09:27:55Z",
+          "secsSpent": 3000,
+          "timeSpent": "50m",
+          "comment": ""
+        }
+      ]
+    }
+  ]
+}
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestReportExport_json_agg_today_1.snap
+++ b/tests/cli/__snapshots__/TestReportExport_json_agg_today_1.snap
@@ -1,0 +1,24 @@
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "days": [
+    {
+      "date": "2025/10/24",
+      "totalSecsSpent": 5700,
+      "totalTimeSpent": "1h 35m",
+      "entries": [
+        {
+          "taskId": 3,
+          "task": "clojure",
+          "numEntries": 2,
+          "secsSpent": 5700,
+          "timeSpent": "1h 35m"
+        }
+      ]
+    }
+  ]
+}
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestReportExport_json_today_1.snap
+++ b/tests/cli/__snapshots__/TestReportExport_json_today_1.snap
@@ -1,0 +1,35 @@
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "days": [
+    {
+      "date": "2025/10/24",
+      "totalSecsSpent": 5700,
+      "totalTimeSpent": "1h 35m",
+      "entries": [
+        {
+          "taskId": 3,
+          "task": "clojure",
+          "beginTs": "2025-10-24T07:27:40Z",
+          "endTs": "2025-10-24T08:12:40Z",
+          "secsSpent": 2700,
+          "timeSpent": "45m",
+          "comment": "write report\n\nThis is a sample task log comment. The comment can be used to record\nadditional information for a task log.\n\nYou can include:\n- Detailed steps taken during the task\n- Observations and notes\n- Any issues encountered and how they were resolved\n- Future actions or follow-ups required\n- References to related tasks or documents\n\nUse this section to ensure all relevant details are captured for each task,\nproviding a comprehensive log that can be referred to later."
+        },
+        {
+          "taskId": 3,
+          "task": "clojure",
+          "beginTs": "2025-10-24T08:37:55Z",
+          "endTs": "2025-10-24T09:27:55Z",
+          "secsSpent": 3000,
+          "timeSpent": "50m",
+          "comment": ""
+        }
+      ]
+    }
+  ]
+}
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestStatsExport_csv_3d_1.snap
+++ b/tests/cli/__snapshots__/TestStatsExport_csv_3d_1.snap
@@ -1,0 +1,16 @@
+success: true
+exit_code: 0
+----- stdout -----
+taskId,task,numEntries,secsSpent,timeSpent
+3,clojure,4,11460,3h 11m
+6,swift,3,10500,2h 55m
+4,typescript,2,6240,1h 44m
+1,haskell,1,5160,1h 26m
+8,ocaml,2,5100,1h 25m
+5,rust,1,4500,1h 15m
+2,clojure,1,3720,1h 2m
+10,c++,1,2520,42m
+7,.net,1,2520,42m
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestStatsExport_csv_all_1.snap
+++ b/tests/cli/__snapshots__/TestStatsExport_csv_all_1.snap
@@ -1,0 +1,17 @@
+success: true
+exit_code: 0
+----- stdout -----
+taskId,task,numEntries,secsSpent,timeSpent
+2,clojure,27,96960,26h 56m
+5,rust,25,93900,26h 5m
+4,typescript,24,84720,23h 32m
+8,ocaml,27,83640,23h 14m
+6,swift,21,79920,22h 12m
+7,.net,24,79680,22h 8m
+9,c,21,76500,21h 15m
+3,clojure,23,76020,21h 7m
+10,c++,19,63540,17h 39m
+1,haskell,17,56460,15h 41m
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestStatsExport_csv_today_1.snap
+++ b/tests/cli/__snapshots__/TestStatsExport_csv_today_1.snap
@@ -1,0 +1,8 @@
+success: true
+exit_code: 0
+----- stdout -----
+taskId,task,numEntries,secsSpent,timeSpent
+3,clojure,2,5700,1h 35m
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestStatsExport_json_3d_1.snap
+++ b/tests/cli/__snapshots__/TestStatsExport_json_3d_1.snap
@@ -1,0 +1,73 @@
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "entries": [
+    {
+      "taskId": 3,
+      "task": "clojure",
+      "numEntries": 4,
+      "secsSpent": 11460,
+      "timeSpent": "3h 11m"
+    },
+    {
+      "taskId": 6,
+      "task": "swift",
+      "numEntries": 3,
+      "secsSpent": 10500,
+      "timeSpent": "2h 55m"
+    },
+    {
+      "taskId": 4,
+      "task": "typescript",
+      "numEntries": 2,
+      "secsSpent": 6240,
+      "timeSpent": "1h 44m"
+    },
+    {
+      "taskId": 1,
+      "task": "haskell",
+      "numEntries": 1,
+      "secsSpent": 5160,
+      "timeSpent": "1h 26m"
+    },
+    {
+      "taskId": 8,
+      "task": "ocaml",
+      "numEntries": 2,
+      "secsSpent": 5100,
+      "timeSpent": "1h 25m"
+    },
+    {
+      "taskId": 5,
+      "task": "rust",
+      "numEntries": 1,
+      "secsSpent": 4500,
+      "timeSpent": "1h 15m"
+    },
+    {
+      "taskId": 2,
+      "task": "clojure",
+      "numEntries": 1,
+      "secsSpent": 3720,
+      "timeSpent": "1h 2m"
+    },
+    {
+      "taskId": 10,
+      "task": "c++",
+      "numEntries": 1,
+      "secsSpent": 2520,
+      "timeSpent": "42m"
+    },
+    {
+      "taskId": 7,
+      "task": ".net",
+      "numEntries": 1,
+      "secsSpent": 2520,
+      "timeSpent": "42m"
+    }
+  ]
+}
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestStatsExport_json_all_1.snap
+++ b/tests/cli/__snapshots__/TestStatsExport_json_all_1.snap
@@ -1,0 +1,80 @@
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "entries": [
+    {
+      "taskId": 2,
+      "task": "clojure",
+      "numEntries": 27,
+      "secsSpent": 96960,
+      "timeSpent": "26h 56m"
+    },
+    {
+      "taskId": 5,
+      "task": "rust",
+      "numEntries": 25,
+      "secsSpent": 93900,
+      "timeSpent": "26h 5m"
+    },
+    {
+      "taskId": 4,
+      "task": "typescript",
+      "numEntries": 24,
+      "secsSpent": 84720,
+      "timeSpent": "23h 32m"
+    },
+    {
+      "taskId": 8,
+      "task": "ocaml",
+      "numEntries": 27,
+      "secsSpent": 83640,
+      "timeSpent": "23h 14m"
+    },
+    {
+      "taskId": 6,
+      "task": "swift",
+      "numEntries": 21,
+      "secsSpent": 79920,
+      "timeSpent": "22h 12m"
+    },
+    {
+      "taskId": 7,
+      "task": ".net",
+      "numEntries": 24,
+      "secsSpent": 79680,
+      "timeSpent": "22h 8m"
+    },
+    {
+      "taskId": 9,
+      "task": "c",
+      "numEntries": 21,
+      "secsSpent": 76500,
+      "timeSpent": "21h 15m"
+    },
+    {
+      "taskId": 3,
+      "task": "clojure",
+      "numEntries": 23,
+      "secsSpent": 76020,
+      "timeSpent": "21h 7m"
+    },
+    {
+      "taskId": 10,
+      "task": "c++",
+      "numEntries": 19,
+      "secsSpent": 63540,
+      "timeSpent": "17h 39m"
+    },
+    {
+      "taskId": 1,
+      "task": "haskell",
+      "numEntries": 17,
+      "secsSpent": 56460,
+      "timeSpent": "15h 41m"
+    }
+  ]
+}
+
+----- stderr -----
+

--- a/tests/cli/__snapshots__/TestStatsExport_json_today_1.snap
+++ b/tests/cli/__snapshots__/TestStatsExport_json_today_1.snap
@@ -1,0 +1,17 @@
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "entries": [
+    {
+      "taskId": 3,
+      "task": "clojure",
+      "numEntries": 2,
+      "secsSpent": 5700,
+      "timeSpent": "1h 35m"
+    }
+  ]
+}
+
+----- stderr -----
+

--- a/tests/cli/export_test.go
+++ b/tests/cli/export_test.go
@@ -1,0 +1,155 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReportExport(t *testing.T) {
+	// GIVEN
+	fx := NewFixture(t, testBinaryPath)
+	now := time.Date(2025, time.October, 24, 12, 0, 0, 0, time.UTC)
+
+	_, err := fx.RunGen(42, now)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name   string
+		args   []string
+		period string
+	}{
+		{name: "json today", args: []string{"report", "--format", "json"}, period: "today"},
+		{name: "csv today", args: []string{"report", "--format", "csv"}, period: "today"},
+		{name: "json 3d", args: []string{"report", "--format", "json"}, period: "3d"},
+		{name: "csv 3d", args: []string{"report", "--format", "csv"}, period: "3d"},
+		{name: "json agg today", args: []string{"report", "--format", "json", "--agg"}, period: "today"},
+		{name: "csv agg today", args: []string{"report", "--format", "csv", "--agg"}, period: "today"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// WHEN
+			cmd := NewCmd(tc.args)
+			cmd.AddArgs(tc.period)
+			cmd.SetEnv("HOURS_NOW", now.Format(time.RFC3339))
+			cmd.UseDB()
+
+			result, runErr := fx.RunCmd(cmd)
+
+			// THEN
+			require.NoError(t, runErr)
+			snaps.MatchStandaloneSnapshot(t, result)
+		})
+	}
+}
+
+func TestLogExport(t *testing.T) {
+	// GIVEN
+	fx := NewFixture(t, testBinaryPath)
+	now := time.Date(2025, time.October, 24, 12, 0, 0, 0, time.UTC)
+
+	_, err := fx.RunGen(42, now)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name   string
+		format string
+		period string
+	}{
+		{name: "json today", format: "json", period: "today"},
+		{name: "csv today", format: "csv", period: "today"},
+		{name: "json 3d", format: "json", period: "3d"},
+		{name: "csv 3d", format: "csv", period: "3d"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// WHEN
+			cmd := NewCmd([]string{"log", "--format", tc.format})
+			cmd.AddArgs(tc.period)
+			cmd.SetEnv("HOURS_NOW", now.Format(time.RFC3339))
+			cmd.UseDB()
+
+			result, runErr := fx.RunCmd(cmd)
+
+			// THEN
+			require.NoError(t, runErr)
+			snaps.MatchStandaloneSnapshot(t, result)
+		})
+	}
+}
+
+func TestStatsExport(t *testing.T) {
+	// GIVEN
+	fx := NewFixture(t, testBinaryPath)
+	now := time.Date(2025, time.October, 24, 12, 0, 0, 0, time.UTC)
+
+	_, err := fx.RunGen(42, now)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name   string
+		format string
+		period string
+	}{
+		{name: "json today", format: "json", period: "today"},
+		{name: "csv today", format: "csv", period: "today"},
+		{name: "json 3d", format: "json", period: "3d"},
+		{name: "csv 3d", format: "csv", period: "3d"},
+		{name: "json all", format: "json", period: "all"},
+		{name: "csv all", format: "csv", period: "all"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// WHEN
+			cmd := NewCmd([]string{"stats", "--format", tc.format})
+			cmd.AddArgs(tc.period)
+			cmd.SetEnv("HOURS_NOW", now.Format(time.RFC3339))
+			cmd.UseDB()
+
+			result, runErr := fx.RunCmd(cmd)
+
+			// THEN
+			require.NoError(t, runErr)
+			snaps.MatchStandaloneSnapshot(t, result)
+		})
+	}
+}
+
+func TestExportFormatErrors(t *testing.T) {
+	// GIVEN
+	fx := NewFixture(t, testBinaryPath)
+	now := time.Date(2025, time.October, 24, 12, 0, 0, 0, time.UTC)
+
+	_, err := fx.RunGen(42, now)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "report interactive json", args: []string{"report", "--interactive", "--format", "json", "today"}},
+		{name: "log interactive json", args: []string{"log", "--interactive", "--format", "json", "today"}},
+		{name: "stats interactive json", args: []string{"stats", "--interactive", "--format", "json", "today"}},
+		{name: "report incorrect format", args: []string{"report", "--format", "xml", "today"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// WHEN
+			cmd := NewCmd(tc.args)
+			cmd.SetEnv("HOURS_NOW", now.Format(time.RFC3339))
+			cmd.UseDB()
+
+			result, runErr := fx.RunCmd(cmd)
+
+			// THEN
+			require.NoError(t, runErr)
+			snaps.MatchStandaloneSnapshot(t, result)
+		})
+	}
+}

--- a/tests/cli/export_test.go
+++ b/tests/cli/export_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	flagFormat      = "--format"
+	flagInteractive = "--interactive"
+)
+
 func TestReportExport(t *testing.T) {
 	// GIVEN
 	fx := NewFixture(t, testBinaryPath)
@@ -21,12 +26,12 @@ func TestReportExport(t *testing.T) {
 		args   []string
 		period string
 	}{
-		{name: "json today", args: []string{"report", "--format", "json"}, period: "today"},
-		{name: "csv today", args: []string{"report", "--format", "csv"}, period: "today"},
-		{name: "json 3d", args: []string{"report", "--format", "json"}, period: "3d"},
-		{name: "csv 3d", args: []string{"report", "--format", "csv"}, period: "3d"},
-		{name: "json agg today", args: []string{"report", "--format", "json", "--agg"}, period: "today"},
-		{name: "csv agg today", args: []string{"report", "--format", "csv", "--agg"}, period: "today"},
+		{name: "json today", args: []string{"report", flagFormat, "json"}, period: "today"},
+		{name: "csv today", args: []string{"report", flagFormat, "csv"}, period: "today"},
+		{name: "json 3d", args: []string{"report", flagFormat, "json"}, period: "3d"},
+		{name: "csv 3d", args: []string{"report", flagFormat, "csv"}, period: "3d"},
+		{name: "json agg today", args: []string{"report", flagFormat, "json", "--agg"}, period: "today"},
+		{name: "csv agg today", args: []string{"report", flagFormat, "csv", "--agg"}, period: "today"},
 	}
 
 	for _, tc := range testCases {
@@ -68,7 +73,7 @@ func TestLogExport(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// WHEN
-			cmd := NewCmd([]string{"log", "--format", tc.format})
+			cmd := NewCmd([]string{"log", flagFormat, tc.format})
 			cmd.AddArgs(tc.period)
 			cmd.SetEnv("HOURS_NOW", now.Format(time.RFC3339))
 			cmd.UseDB()
@@ -106,7 +111,7 @@ func TestStatsExport(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// WHEN
-			cmd := NewCmd([]string{"stats", "--format", tc.format})
+			cmd := NewCmd([]string{"stats", flagFormat, tc.format})
 			cmd.AddArgs(tc.period)
 			cmd.SetEnv("HOURS_NOW", now.Format(time.RFC3339))
 			cmd.UseDB()
@@ -132,10 +137,11 @@ func TestExportFormatErrors(t *testing.T) {
 		name string
 		args []string
 	}{
-		{name: "report interactive json", args: []string{"report", "--interactive", "--format", "json", "today"}},
-		{name: "log interactive json", args: []string{"log", "--interactive", "--format", "json", "today"}},
-		{name: "stats interactive json", args: []string{"stats", "--interactive", "--format", "json", "today"}},
-		{name: "report incorrect format", args: []string{"report", "--format", "xml", "today"}},
+		{name: "report interactive json", args: []string{"report", flagInteractive, flagFormat, "json", "today"}},
+		{name: "log interactive json", args: []string{"log", flagInteractive, flagFormat, "json", "today"}},
+		{name: "stats interactive json", args: []string{"stats", flagInteractive, flagFormat, "json", "today"}},
+		{name: "report incorrect format", args: []string{"report", flagFormat, "xml", "today"}},
+		{name: "report plain json", args: []string{"report", "--plain", flagFormat, "json", "today"}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

Adds JSON and CSV export support to the `report`, `log`, and `stats` commands via a new `--format` / `-f` flag. The default behavior (`plain`) is unchanged and still renders the existing ASCII table output.

## CLI changes

- Added `--format` / `-f` flag to `report`, `log`, and `stats`
- Accepted values: `plain` (default), `json`, `csv`
- Updated command help text to mention the new export option
- Each command parses the format with `types.ParseOutputFormat()` and passes it into the corresponding render function

### Examples

```bash
hours report today --format json
hours report 3d --format csv --agg
hours log today -f csv
hours stats all --format json