### PR TITLE
show time tracked in the day

### DIFF
--- a/docs/tui/time-tracked-in-the-day-so-far.md
+++ b/docs/tui/time-tracked-in-the-day-so-far.md
@@ -1,0 +1,86 @@
+# Time tracked in the day so far
+
+## Purpose and scope
+
+The TUI presents the amount of time tracked during the user's current local
+calendar day as a lightweight footer summary. It combines completed and active
+tracking time and appears across TUI views once the total reaches one minute.
+
+This metric is a day-progress signal, not a reporting primitive. It does not
+provide a saved-versus-active breakdown and is not intended to replace the app's
+reporting flows.
+
+## Domain constraints
+
+`Today` means the user's local calendar day, beginning at local midnight. It is
+not a rolling 24-hour period. Calendar-day boundaries must respect the current
+location and daylight-saving transitions.
+
+Only elapsed time that overlaps the interval from local midnight to the current
+time belongs to the total. This applies equally to completed and active task
+logs. In particular, logs that cross midnight contribute only their portion
+within the current day.
+
+## Architectural direction
+
+The daily total is derived TUI state. Its inputs are:
+
+- the recent completed task logs already cached by the TUI;
+- active tracking state;
+- the current time.
+
+The TUI does not fetch a separate database aggregate for this metric. The
+summary and the rest of the interface therefore share the same in-memory view of
+task-log data.
+
+This choice keeps the feature proportional to its role as a convenience summary.
+It avoids a second source of truth and avoids coordinating aggregate refreshes
+with every task-log mutation.
+
+Rendering consumes the derived value without calculating it or reading the
+clock. This keeps rendering deterministic and free of side effects.
+
+## Time-driven updates
+
+Model changes keep the total synchronized with task-log mutations, but they are
+not sufficient while the user is idle. Active tracking continues to accrue, and
+the local day can change at midnight without any user input.
+
+The TUI therefore maintains a lightweight periodic update signal for its
+lifetime. The signal performs no database I/O; it only gives the model an
+opportunity to derive the total using the latest time. It remains active even
+when nothing is currently being tracked so that midnight transitions are
+reflected automatically.
+
+A coarse cadence is sufficient because the footer displays minute-level
+progress. Keeping one lifetime update mechanism is intentionally preferred over
+switching between active-tracking updates and a separate midnight wake-up.
+
+## Completeness tradeoff
+
+The total is based on a bounded window of recent task logs rather than all
+matching rows in the database. This means it can undercount on unusually
+high-volume days and can remain stale when the database changes outside the
+running TUI.
+
+That limitation is accepted in exchange for:
+
+- simpler state management;
+- consistency between the footer and the visible TUI state;
+- deterministic rendering;
+- no periodic database work;
+- no mutation-specific aggregate refresh orchestration.
+
+Reporting flows remain the authoritative path when completeness is required.
+
+## Architectural invariants
+
+- Interpret today as the current local calendar day.
+- Count only elapsed time that overlaps the current day.
+- Include both completed and active tracking time.
+- Derive the total from existing TUI state rather than maintaining it
+    incrementally.
+- Keep rendering free of clock reads and state changes.
+- Keep a time-driven update active for the lifetime of the TUI.
+- Do not perform database I/O solely to refresh this footer metric.
+- Treat the value as a convenience summary, not an authoritative aggregate.

--- a/docs/tui/time-tracked-today.md
+++ b/docs/tui/time-tracked-today.md
@@ -1,4 +1,4 @@
-# Time tracked in the day so far
+# Time tracked today
 
 ## Purpose and scope
 

--- a/internal/domain/duration.go
+++ b/internal/domain/duration.go
@@ -1,0 +1,64 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/dhth/hours/internal/types"
+)
+
+func SecondsTrackedToday(
+	finishedTaskLogs []types.TaskLogEntry,
+	activeTaskLogBeginTS *time.Time,
+	now time.Time,
+) int {
+	startOfDay := time.Date(
+		now.Year(),
+		now.Month(),
+		now.Day(),
+		0, 0, 0, 0,
+		now.Location(),
+	)
+
+	var trackedSeconds int
+	for _, entry := range finishedTaskLogs {
+		trackedSeconds += overlappingSeconds(
+			entry.BeginTS,
+			entry.EndTS,
+			startOfDay,
+			now,
+		)
+	}
+
+	if activeTaskLogBeginTS != nil && !activeTaskLogBeginTS.IsZero() {
+		trackedSeconds += overlappingSeconds(
+			*activeTaskLogBeginTS,
+			now,
+			startOfDay,
+			now,
+		)
+	}
+
+	return trackedSeconds
+}
+
+func overlappingSeconds(begin, end, rangeStart, rangeEnd time.Time) int {
+	if !end.After(begin) || !rangeEnd.After(rangeStart) {
+		return 0
+	}
+
+	overlapStart := begin
+	if overlapStart.Before(rangeStart) {
+		overlapStart = rangeStart
+	}
+
+	overlapEnd := end
+	if overlapEnd.After(rangeEnd) {
+		overlapEnd = rangeEnd
+	}
+
+	if !overlapEnd.After(overlapStart) {
+		return 0
+	}
+
+	return int(overlapEnd.Sub(overlapStart).Seconds())
+}

--- a/internal/domain/duration_test.go
+++ b/internal/domain/duration_test.go
@@ -1,0 +1,181 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dhth/hours/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverlappingSeconds(t *testing.T) {
+	// GIVEN
+	rangeStart := timestamp(t, "2026-07-16T09:00:00Z")
+	rangeEnd := timestamp(t, "2026-07-16T17:00:00Z")
+	testCases := []struct {
+		name            string
+		begin           string
+		end             string
+		expectedSeconds int
+	}{
+		{
+			name:            "entirely within range",
+			begin:           "2026-07-16T10:00:00Z",
+			end:             "2026-07-16T12:30:00Z",
+			expectedSeconds: (2*60 + 30) * 60,
+		},
+		{
+			name:            "overlaps range start",
+			begin:           "2026-07-16T08:00:00Z",
+			end:             "2026-07-16T10:00:00Z",
+			expectedSeconds: 60 * 60,
+		},
+		{
+			name:            "overlaps range end",
+			begin:           "2026-07-16T16:00:00Z",
+			end:             "2026-07-16T18:00:00Z",
+			expectedSeconds: 60 * 60,
+		},
+		{
+			name:            "spans entire range",
+			begin:           "2026-07-16T08:00:00Z",
+			end:             "2026-07-16T18:00:00Z",
+			expectedSeconds: 8 * 60 * 60,
+		},
+		{
+			name:            "entirely before range",
+			begin:           "2026-07-16T07:00:00Z",
+			end:             "2026-07-16T08:00:00Z",
+			expectedSeconds: 0,
+		},
+		{
+			name:            "entirely after range",
+			begin:           "2026-07-16T18:00:00Z",
+			end:             "2026-07-16T19:00:00Z",
+			expectedSeconds: 0,
+		},
+		{
+			name:            "ends at range start",
+			begin:           "2026-07-16T08:00:00Z",
+			end:             "2026-07-16T09:00:00Z",
+			expectedSeconds: 0,
+		},
+		{
+			name:            "begins at range end",
+			begin:           "2026-07-16T17:00:00Z",
+			end:             "2026-07-16T18:00:00Z",
+			expectedSeconds: 0,
+		},
+		{
+			name:            "zero length interval",
+			begin:           "2026-07-16T12:00:00Z",
+			end:             "2026-07-16T12:00:00Z",
+			expectedSeconds: 0,
+		},
+		{
+			name:            "reversed interval",
+			begin:           "2026-07-16T13:00:00Z",
+			end:             "2026-07-16T12:00:00Z",
+			expectedSeconds: 0,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			begin := timestamp(t, tt.begin)
+			end := timestamp(t, tt.end)
+
+			// WHEN
+			got := overlappingSeconds(begin, end, rangeStart, rangeEnd)
+
+			// THEN
+			assert.Equal(t, tt.expectedSeconds, got)
+		})
+	}
+}
+
+func TestSecondsTrackedToday(t *testing.T) {
+	now := timestamp(t, "2026-01-16T14:00:00+01:00")
+	taskLogsWithinDay := []types.TaskLogEntry{
+		{
+			BeginTS: timestamp(t, "2026-01-16T09:15:00+01:00"),
+			EndTS:   timestamp(t, "2026-01-16T10:45:00+01:00"),
+		},
+		{
+			BeginTS: timestamp(t, "2026-01-16T11:30:00+01:00"),
+			EndTS:   timestamp(t, "2026-01-16T12:15:00+01:00"),
+		},
+	}
+	taskLogsCrossingMidnight := []types.TaskLogEntry{
+		{
+			BeginTS: timestamp(t, "2026-01-15T23:15:00+01:00"),
+			EndTS:   timestamp(t, "2026-01-16T00:45:00+01:00"),
+		},
+	}
+	zeroTimestamp := time.Time{}
+	activeTaskLogBeginTSWithinDay := timestamp(t, "2026-01-16T13:00:00+01:00")
+	activeTaskLogBeginTSBeforeMidnight := timestamp(t, "2026-01-15T23:15:00+01:00")
+
+	testCases := []struct {
+		name                 string
+		finishedTaskLogs     []types.TaskLogEntry
+		activeTaskLogBeginTS *time.Time
+		expectedSeconds      int
+	}{
+		{
+			name:            "no task logs",
+			expectedSeconds: 0,
+		},
+		{
+			name:                 "zero active task log begin timestamp",
+			activeTaskLogBeginTS: &zeroTimestamp,
+			expectedSeconds:      0,
+		},
+		{
+			name:             "task logs within today",
+			finishedTaskLogs: taskLogsWithinDay,
+			expectedSeconds:  (90 + 45) * 60,
+		},
+		{
+			name:                 "task logs within today and an active task",
+			finishedTaskLogs:     taskLogsWithinDay,
+			activeTaskLogBeginTS: &activeTaskLogBeginTSWithinDay,
+			expectedSeconds:      (90 + 45 + 60) * 60,
+		},
+		{
+			name:             "task log crossing midnight",
+			finishedTaskLogs: taskLogsCrossingMidnight,
+			expectedSeconds:  45 * 60,
+		},
+		{
+			name:                 "active task log beginning before midnight",
+			activeTaskLogBeginTS: &activeTaskLogBeginTSBeforeMidnight,
+			expectedSeconds:      14 * 60 * 60,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			// GIVEN
+			// WHEN
+			got := SecondsTrackedToday(
+				tt.finishedTaskLogs,
+				tt.activeTaskLogBeginTS,
+				now,
+			)
+
+			// THEN
+			assert.Equal(t, tt.expectedSeconds, got)
+		})
+	}
+}
+
+func timestamp(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	timestamp, err := time.Parse(time.RFC3339, value)
+	require.NoError(t, err)
+
+	return timestamp
+}

--- a/internal/ui/__snapshots__/TestTaskLogViewEmpty_1.snap
+++ b/internal/ui/__snapshots__/TestTaskLogViewEmpty_1.snap
@@ -1,32 +1,32 @@
-                           
-   Task Logs (last 50)     
-                           
-  No entries               
-                           
-No entries.                
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
-                           
- hours   Press ? for help  
+                            
+   Task Logs (last 100)     
+                            
+  No entries                
+                            
+No entries.                 
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+ hours   Press ? for help   

--- a/internal/ui/__snapshots__/TestTerminalWidthResizingWorks_1.snap
+++ b/internal/ui/__snapshots__/TestTerminalWidthResizingWorks_1.snap
@@ -1,5 +1,5 @@
                                                                                 
-   Task Logs (last 50)                                                          
+   Task Logs (last 100)                                                         
                                                                                 
   3 entries                                                                     
                                                                                 

--- a/internal/ui/__snapshots__/TestTimeTrackedTodayInFooter_1.snap
+++ b/internal/ui/__snapshots__/TestTimeTrackedTodayInFooter_1.snap
@@ -1,16 +1,11 @@
                                                                                                 
    Task Logs (last 100)                                                                         
                                                                                                 
-  3 entries                                                                                     
+  1 entry                                                                                       
                                                                                                 
 │ Test work on task                                                                             
 │ Implement feature A                                          06:30  ...  08:00             …  
                                                                                                 
-  Test work on task                                                                             
-  Fix bug in module B                                          06:30  ...  08:00             …  
-                                                                                                
-  Test work on task                                                                             
-  Implement feature A                                          06:30  ...  08:00             …  
                                                                                                 
                                                                                                 
                                                                                                 
@@ -29,4 +24,9 @@
                                                                                                 
                                                                                                 
                                                                                                 
- hours   Press ? for help                                                                       
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+                                                                                                
+ hours   Press ? for help  tracked today: 1h 30m                                                

--- a/internal/ui/cmds.go
+++ b/internal/ui/cmds.go
@@ -120,7 +120,7 @@ func updateTaskRep(db *sql.DB, t *types.Task) tea.Cmd {
 
 func fetchTLS(db *sql.DB, tlIDToFocusOn *int) tea.Cmd {
 	return func() tea.Msg {
-		entries, err := pers.FetchTLEntries(db, true, 50)
+		entries, err := pers.FetchTLEntries(db, true, taskLogFetchLimit)
 		return tLsFetchedMsg{
 			entries:       entries,
 			tlIDToFocusOn: tlIDToFocusOn,
@@ -177,6 +177,12 @@ func fetchTasks(db *sql.DB, active bool) tea.Cmd {
 func hideHelp(interval time.Duration) tea.Cmd {
 	return tea.Tick(interval, func(time.Time) tea.Msg {
 		return hideHelpMsg{}
+	})
+}
+
+func tickTimeTrackedToday(interval time.Duration) tea.Cmd {
+	return tea.Tick(interval, func(time.Time) tea.Msg {
+		return timeTrackedTodayTickMsg{}
 	})
 }
 

--- a/internal/ui/initial.go
+++ b/internal/ui/initial.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"database/sql"
+	"fmt"
 
 	"charm.land/bubbles/v2/list"
 	"charm.land/bubbles/v2/textarea"
@@ -95,7 +96,7 @@ This can be used to record details about your work on this task.`
 	m.activeTasksList.KeyMap.PrevPage.SetKeys("left", "h", "pgup")
 	m.activeTasksList.KeyMap.NextPage.SetKeys("right", "l", "pgdown")
 
-	m.taskLogList.Title = "Task Logs (last 50)"
+	m.taskLogList.Title = fmt.Sprintf("Task Logs (last %d)", taskLogFetchLimit)
 	m.taskLogList.SetStatusBarItemName("entry", "entries")
 	m.taskLogList.SetFilteringEnabled(false)
 	m.taskLogList.DisableQuitKeybindings()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	"github.com/dhth/hours/internal/domain"
 	"github.com/dhth/hours/internal/types"
 )
 
@@ -77,6 +78,7 @@ const (
 	timeOnlyFormat       = "15:04"
 	dateFormat           = "2006/01/02"
 	userMsgDefaultFrames = 3
+	taskLogFetchLimit    = 100
 )
 
 type userMsgKind uint
@@ -131,6 +133,7 @@ type Model struct {
 	showHelpIndicator              bool
 	terminalWidth                  int
 	terminalHeight                 int
+	secsTrackedToday               int
 	trackingActive                 bool
 	debug                          bool
 	frameCounter                   uint
@@ -147,9 +150,32 @@ func (m *Model) blurTLTrackingInputs() {
 func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		hideHelp(time.Minute*1),
+		tickTimeTrackedToday(30*time.Second),
 		fetchTasks(m.db, true),
 		fetchTLS(m.db, nil),
 		fetchTasks(m.db, false),
+	)
+}
+
+func (m *Model) recalculateSecondsTrackedToday() {
+	items := m.taskLogList.Items()
+	finishedTaskLogs := make([]types.TaskLogEntry, 0, len(items))
+	for _, item := range items {
+		entry, ok := item.(types.TaskLogEntry)
+		if ok {
+			finishedTaskLogs = append(finishedTaskLogs, entry)
+		}
+	}
+
+	var activeTaskLogBeginTS *time.Time
+	if m.trackingActive {
+		activeTaskLogBeginTS = &m.activeTLBeginTS
+	}
+
+	m.secsTrackedToday = domain.SecondsTrackedToday(
+		finishedTaskLogs,
+		activeTaskLogBeginTS,
+		m.timeProvider.Now(),
 	)
 }
 

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -8,6 +8,8 @@ import (
 
 type hideHelpMsg struct{}
 
+type timeTrackedTodayTickMsg struct{}
+
 type trackingToggledMsg struct {
 	taskID    int
 	finished  bool

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -36,6 +36,7 @@ type Style struct {
 	taskEntryHeading     lipgloss.Style
 	taskLogDetails       lipgloss.Style
 	taskLogEntryHeading  lipgloss.Style
+	trackedToday         lipgloss.Style
 	theme                theme.Theme
 	titleForegroundColor color.Color
 	tlFormOkStyle        lipgloss.Style
@@ -60,14 +61,16 @@ func NewStyle(theme theme.Theme) Style {
 		PaddingRight(1).
 		Foreground(lipgloss.Color(theme.TitleForeground))
 
-	helpMsg := lipgloss.NewStyle().
-		PaddingLeft(1).
+	helpMsg := lipgloss.NewStyle().PaddingLeft(2).
 		Bold(true).
 		Foreground(lipgloss.Color(theme.HelpMsg))
 
-	tracking := lipgloss.NewStyle().
-		PaddingLeft(2).
-		Bold(true).
+	footerItem := lipgloss.NewStyle().PaddingLeft(2).Bold(true)
+
+	trackedToday := footerItem.
+		Foreground(lipgloss.Color(theme.InactiveTasks))
+
+	tracking := footerItem.
 		Foreground(lipgloss.Color(theme.Tracking))
 
 	helpTitle := base.
@@ -98,6 +101,7 @@ func NewStyle(theme theme.Theme) Style {
 		taskEntryHeading:     baseHeading.Background(lipgloss.Color(theme.TaskEntry)),
 		taskLogDetails:       helpTitle.Background(lipgloss.Color(theme.TaskLogDetailsViewTitle)),
 		taskLogEntryHeading:  baseHeading.Background(lipgloss.Color(theme.TaskLogEntry)),
+		trackedToday:         trackedToday,
 		theme:                theme,
 		titleForegroundColor: lipgloss.Color(theme.TitleForeground),
 		tlFormOkStyle:        lipgloss.NewStyle().Foreground(lipgloss.Color(theme.TaskLogFormInfo)),

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -18,12 +18,21 @@ const (
 )
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	model, cmd := m.processMessage(msg)
+	model.recalculateSecondsTrackedToday()
+
+	return model, cmd
+}
+
+func (m Model) processMessage(msg tea.Msg) (Model, tea.Cmd) {
 	m.frameCounter++
 	var cmd tea.Cmd
 	var cmds []tea.Cmd
 
-	// early check for window resizing and handling insufficient dimensions
+	// Handle the time-tracking tick, window resizing, and insufficient dimensions early
 	switch msg := msg.(type) {
+	case timeTrackedTodayTickMsg:
+		cmds = append(cmds, tickTimeTrackedToday(30*time.Second))
 	case tea.WindowSizeMsg:
 		m.handleWindowResizing(msg)
 	case tea.KeyPressMsg:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -292,23 +292,32 @@ func (m Model) View() tea.View {
 		// first time directions
 		if m.activeView == taskListView && len(m.activeTasksList.Items()) <= 1 {
 			if len(m.activeTasksList.Items()) == 0 {
-				helpMsg += " " + m.style.initialHelpMsg.Render("Press a to add a task")
+				helpMsg += m.style.initialHelpMsg.Render("Press a to add a task")
 			} else if len(m.taskLogList.Items()) == 0 {
 				if m.trackingActive {
-					helpMsg += " " + m.style.initialHelpMsg.Render("Press s to stop tracking time")
+					helpMsg += m.style.initialHelpMsg.Render("Press s to stop tracking time")
 				} else {
-					helpMsg += " " + m.style.initialHelpMsg.Render("Press s to start tracking time")
+					helpMsg += m.style.initialHelpMsg.Render("Press s to start tracking time")
 				}
 			}
 		}
 
-		helpMsg += " " + m.style.helpMsg.Render("Press ? for help")
+		helpMsg += m.style.helpMsg.Render("Press ? for help")
+	}
+
+	var trackedTodayMsg string
+	if m.secsTrackedToday >= 60 {
+		trackedTodayMsg = m.style.trackedToday.Render(fmt.Sprintf(
+			"tracked today: %s",
+			types.HumanizeDuration(m.secsTrackedToday),
+		))
 	}
 
 	footer = fmt.Sprintf(
-		"%s%s%s",
+		"%s%s%s%s",
 		m.style.toolName.Render("hours"),
 		helpMsg,
+		trackedTodayMsg,
 		activeMsg,
 	)
 

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -162,6 +162,22 @@ func TestInactiveTaskListViewWithTasks(t *testing.T) {
 	snaps.MatchStandaloneSnapshot(t, result)
 }
 
+func TestTimeTrackedTodayInFooter(t *testing.T) {
+	// GIVEN
+	m := createTestModel()
+	m.activeView = taskLogView
+	m.secsTrackedToday = 90 * 60
+
+	entry1 := createTestTaskLogEntry(1, 1, "Implement feature A", m.timeProvider)
+	m.taskLogList.SetItems([]list.Item{entry1})
+
+	// WHEN
+	result := stripANSI(m.View().Content)
+
+	// THEN
+	snaps.MatchStandaloneSnapshot(t, result)
+}
+
 func TestCreateTaskViewWithNoInput(t *testing.T) {
 	// GIVEN
 	m := createTestModel()

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ fmt:
     gofumpt -l -w .
 
 install:
-    go install .
+    go install -ldflags "-w -s" .
 
 check:
     golangci-lint run


### PR DESCRIPTION
# Time tracked in the day so far

## Purpose and scope

The TUI presents the amount of time tracked during the user's current local calendar day as a lightweight footer summary. It combines completed and active tracking time and appears across TUI views once the total reaches one minute.

This metric is a day-progress signal, not a reporting primitive. It does not provide a saved-versus-active breakdown and is not intended to replace the app's reporting flows.

## Domain constraints

`Today` means the user's local calendar day, beginning at local midnight. It is not a rolling 24-hour period. Calendar-day boundaries must respect the current location and daylight-saving transitions.

Only elapsed time that overlaps the interval from local midnight to the current time belongs to the total. This applies equally to completed and active task logs. In particular, logs that cross midnight contribute only their portion within the current day.

## Architectural direction

The daily total is derived TUI state. Its inputs are:

- the recent completed task logs already cached by the TUI;
- active tracking state;
- the current time.

The TUI does not fetch a separate database aggregate for this metric. The summary and the rest of the interface therefore share the same in-memory view of task-log data.

This choice keeps the feature proportional to its role as a convenience summary. It avoids a second source of truth and avoids coordinating aggregate refreshes with every task-log mutation.

Rendering consumes the derived value without calculating it or reading the clock. This keeps rendering deterministic and free of side effects.

## Time-driven updates

Model changes keep the total synchronized with task-log mutations, but they are not sufficient while the user is idle. Active tracking continues to accrue, and the local day can change at midnight without any user input.

The TUI therefore maintains a lightweight periodic update signal for its lifetime. The signal performs no database I/O; it only gives the model an opportunity to derive the total using the latest time. It remains active even when nothing is currently being tracked so that midnight transitions are reflected automatically.

A coarse cadence is sufficient because the footer displays minute-level progress. Keeping one lifetime update mechanism is intentionally preferred over switching between active-tracking updates and a separate midnight wake-up.

## Completeness tradeoff

The total is based on a bounded window of recent task logs rather than all matching rows in the database. This means it can undercount on unusually high-volume days and can remain stale when the database changes outside the running TUI.

That limitation is accepted in exchange for:

- simpler state management;
- consistency between the footer and the visible TUI state;
- deterministic rendering;
- no periodic database work;
- no mutation-specific aggregate refresh orchestration.

Reporting flows remain the authoritative path when completeness is required.

## Architectural invariants

- Interpret today as the current local calendar day.
- Count only elapsed time that overlaps the current day.
- Include both completed and active tracking time.
- Derive the total from existing TUI state rather than maintaining it incrementally.
- Keep rendering free of clock reads and state changes.
- Keep a time-driven update active for the lifetime of the TUI.
- Do not perform database I/O solely to refresh this footer metric.
- Treat the value as a convenience summary, not an authoritative aggregate.
