### PR TITLE
refactor: split up types.Task into domain & ui

### DIFF
--- a/internal/domain/task.go
+++ b/internal/domain/task.go
@@ -1,0 +1,12 @@
+package domain
+
+import "time"
+
+type Task struct {
+	ID        int
+	Summary   string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	SecsSpent int
+	Active    bool
+}

--- a/internal/persistence/queries.go
+++ b/internal/persistence/queries.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dhth/hours/internal/domain"
 	"github.com/dhth/hours/internal/types"
 )
 
@@ -414,7 +415,7 @@ WHERE id = ?
 	return nil
 }
 
-func UpdateTaskData(db *sql.DB, t *types.Task) error {
+func UpdateTaskData(db *sql.DB, t *domain.Task) error {
 	row := db.QueryRow(`
 SELECT secs_spent, updated_at
 FROM task
@@ -431,8 +432,8 @@ WHERE id=?;
 	return nil
 }
 
-func FetchTasks(db *sql.DB, active bool, limit int) ([]types.Task, error) {
-	var tasks []types.Task
+func FetchTasks(db *sql.DB, active bool, limit int) ([]domain.Task, error) {
+	var tasks []domain.Task
 
 	rows, err := db.Query(`
 SELECT id, summary, secs_spent, created_at, updated_at, active
@@ -447,7 +448,7 @@ LIMIT ?;
 	defer rows.Close()
 
 	for rows.Next() {
-		var entry types.Task
+		var entry domain.Task
 		err = rows.Scan(
 			&entry.ID,
 			&entry.Summary,
@@ -794,8 +795,8 @@ func runInTxAndReturnA[A any](db *sql.DB, fn func(tx *sql.Tx) (A, error)) (A, er
 	return zero, err
 }
 
-func fetchTaskByID(db *sql.DB, id int) (types.Task, error) {
-	var task types.Task
+func fetchTaskByID(db *sql.DB, id int) (domain.Task, error) {
+	var task domain.Task
 	row := db.QueryRow(`
 SELECT id, summary, secs_spent, active, created_at, updated_at
 FROM task

--- a/internal/persistence/queries_test.go
+++ b/internal/persistence/queries_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dhth/hours/internal/domain"
 	"github.com/dhth/hours/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -824,14 +825,14 @@ func cleanupDB(t *testing.T, testDB *sql.DB) {
 }
 
 type testData struct {
-	tasks    []types.Task
+	tasks    []domain.Task
 	taskLogs []types.TaskLogEntry
 }
 
 func getTestData(referenceTS time.Time) testData {
 	ua := referenceTS.UTC()
 	ca := ua.Add(time.Hour * 24 * 7 * -1)
-	tasks := []types.Task{
+	tasks := []domain.Task{
 		{
 			ID:        1,
 			Summary:   "seeded task 1",

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -14,18 +14,6 @@ const emptyCommentIndicator = "∅"
 
 var ErrIncorrectTaskStatusProvided = errors.New("incorrect task status provided")
 
-type Task struct {
-	ID             int
-	Summary        string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	TrackingActive bool
-	SecsSpent      int
-	Active         bool
-	ListTitle      string
-	ListDesc       string
-}
-
 type TaskLogEntry struct {
 	ID          int
 	TaskID      int
@@ -78,28 +66,6 @@ func (t TestTimeProvider) Now() time.Time {
 	return t.FixedTime
 }
 
-func (t *Task) UpdateListTitle() {
-	var trackingIndicator string
-	if t.TrackingActive {
-		trackingIndicator = "⏲ "
-	}
-
-	t.ListTitle = trackingIndicator + t.Summary
-}
-
-func (t *Task) UpdateListDesc(timeProvider TimeProvider) {
-	var timeSpent string
-
-	if t.SecsSpent != 0 {
-		timeSpent = "worked on for " + HumanizeDuration(t.SecsSpent)
-	} else {
-		timeSpent = "no time spent"
-	}
-	lastUpdated := fmt.Sprintf("last updated: %s", humanize.RelTime(t.UpdatedAt, timeProvider.Now(), "ago", "from now"))
-
-	t.ListDesc = fmt.Sprintf("%s %s", utils.RightPadTrim(lastUpdated, 60, true), timeSpent)
-}
-
 func (tl *TaskLogEntry) UpdateListTitle() {
 	tl.ListTitle = utils.TrimWithMoreLinesIndicator(tl.GetComment(), 60)
 }
@@ -137,18 +103,6 @@ func (tl *TaskLogEntry) GetComment() string {
 	}
 
 	return *tl.Comment
-}
-
-func (t Task) Title() string {
-	return t.ListTitle
-}
-
-func (t Task) Description() string {
-	return t.ListDesc
-}
-
-func (t Task) FilterValue() string {
-	return t.Summary
 }
 
 func (tl TaskLogEntry) Title() string {

--- a/internal/ui/cmds.go
+++ b/internal/ui/cmds.go
@@ -108,9 +108,9 @@ func fetchActiveTask(db *sql.DB) tea.Cmd {
 	}
 }
 
-func updateTaskRep(db *sql.DB, t *types.Task) tea.Cmd {
+func updateTaskRep(db *sql.DB, t *taskListItem) tea.Cmd {
 	return func() tea.Msg {
-		err := pers.UpdateTaskData(db, t)
+		err := pers.UpdateTaskData(db, &t.Task)
 		return taskRepUpdatedMsg{
 			tsk: t,
 			err: err,
@@ -153,14 +153,14 @@ func createTask(db *sql.DB, summary string) tea.Cmd {
 	}
 }
 
-func updateTask(db *sql.DB, task *types.Task, summary string) tea.Cmd {
+func updateTask(db *sql.DB, task *taskListItem, summary string) tea.Cmd {
 	return func() tea.Msg {
 		err := pers.UpdateTask(db, task.ID, summary)
 		return taskUpdatedMsg{task, summary, err}
 	}
 }
 
-func updateTaskActiveStatus(db *sql.DB, task *types.Task, active bool) tea.Cmd {
+func updateTaskActiveStatus(db *sql.DB, task *taskListItem, active bool) tea.Cmd {
 	return func() tea.Msg {
 		err := pers.UpdateTaskActiveStatus(db, task.ID, active)
 		return taskActiveStatusUpdatedMsg{task, active, err}

--- a/internal/ui/handle.go
+++ b/internal/ui/handle.go
@@ -33,7 +33,7 @@ func (m *Model) getCmdToCreateOrUpdateTask() tea.Cmd {
 		cmd = createTask(m.db, m.taskInputs[summaryField].Value())
 		m.taskInputs[summaryField].SetValue("")
 	case taskUpdateCxt:
-		selectedTask, ok := m.activeTasksList.SelectedItem().(*types.Task)
+		selectedTask, ok := m.activeTasksList.SelectedItem().(*taskListItem)
 		if !ok {
 			m.message = errMsg("Something went wrong")
 			return nil
@@ -127,7 +127,7 @@ func (m *Model) getCmdToCreateOrEditTL() tea.Cmd {
 	switch m.tasklogSaveType {
 	case tasklogInsert:
 		m.activeView = taskListView
-		task, ok := m.activeTasksList.SelectedItem().(*types.Task)
+		task, ok := m.activeTasksList.SelectedItem().(*taskListItem)
 		if !ok {
 			m.message = errMsg(genericErrorMsg)
 			return nil
@@ -401,7 +401,7 @@ func (m *Model) getCmdToDeactivateTask() tea.Cmd {
 		return nil
 	}
 
-	task, ok := m.activeTasksList.SelectedItem().(*types.Task)
+	task, ok := m.activeTasksList.SelectedItem().(*taskListItem)
 	if !ok {
 		m.message = errMsg(msgCouldntSelectATask)
 		return nil
@@ -425,7 +425,7 @@ func (m *Model) getCmdToActivateDeactivatedTask() tea.Cmd {
 		return nil
 	}
 
-	task, ok := m.inactiveTasksList.SelectedItem().(*types.Task)
+	task, ok := m.inactiveTasksList.SelectedItem().(*taskListItem)
 	if !ok {
 		m.message = errMsg(genericErrorMsg)
 		return nil
@@ -435,7 +435,7 @@ func (m *Model) getCmdToActivateDeactivatedTask() tea.Cmd {
 }
 
 func (m *Model) getCmdToStartTracking() tea.Cmd {
-	task, ok := m.activeTasksList.SelectedItem().(*types.Task)
+	task, ok := m.activeTasksList.SelectedItem().(*taskListItem)
 	if !ok {
 		m.message = errMsg(genericErrorMsg)
 		return nil
@@ -466,7 +466,7 @@ func (m *Model) handleRequestToStopTracking() {
 }
 
 func (m *Model) getCmdToQuickSwitchTracking() tea.Cmd {
-	task, ok := m.activeTasksList.SelectedItem().(*types.Task)
+	task, ok := m.activeTasksList.SelectedItem().(*taskListItem)
 	if !ok {
 		m.message = errMsg(genericErrorMsg)
 		return nil
@@ -509,7 +509,7 @@ func (m *Model) handleRequestToUpdateTask() {
 		return
 	}
 
-	task, ok := m.activeTasksList.SelectedItem().(*types.Task)
+	task, ok := m.activeTasksList.SelectedItem().(*taskListItem)
 	if !ok {
 		m.message = errMsg(genericErrorMsg)
 		return
@@ -656,15 +656,16 @@ func (m *Model) handleTasksFetchedMsg(msg tasksFetchedMsg) tea.Cmd {
 	var cmd tea.Cmd
 	switch msg.active {
 	case true:
-		m.taskMap = make(map[int]*types.Task)
+		m.taskMap = make(map[int]*taskListItem)
 		m.taskIndexMap = make(map[int]int)
 		tasks := make([]list.Item, len(msg.tasks))
 		for i, task := range msg.tasks {
-			task.UpdateListTitle()
-			task.UpdateListDesc(m.timeProvider)
-			tasks[i] = &task
-			m.taskMap[task.ID] = &task
-			m.taskIndexMap[task.ID] = i
+			item := &taskListItem{Task: task}
+			item.updateListTitle()
+			item.updateListDesc(m.timeProvider)
+			tasks[i] = item
+			m.taskMap[item.ID] = item
+			m.taskIndexMap[item.ID] = i
 		}
 		m.activeTasksList.SetItems(tasks)
 		m.activeTasksList.Title = "Tasks"
@@ -674,9 +675,10 @@ func (m *Model) handleTasksFetchedMsg(msg tasksFetchedMsg) tea.Cmd {
 	case false:
 		inactiveTasks := make([]list.Item, len(msg.tasks))
 		for i, inactiveTask := range msg.tasks {
-			inactiveTask.UpdateListTitle()
-			inactiveTask.UpdateListDesc(m.timeProvider)
-			inactiveTasks[i] = &inactiveTask
+			item := &taskListItem{Task: inactiveTask}
+			item.updateListTitle()
+			item.updateListDesc(m.timeProvider)
+			inactiveTasks[i] = item
 		}
 		m.inactiveTasksList.SetItems(inactiveTasks)
 	}
@@ -763,8 +765,8 @@ func (m *Model) handleActiveTaskFetchedMsg(msg activeTaskFetchedMsg) {
 
 	activeTask, ok := m.taskMap[m.activeTaskID]
 	if ok {
-		activeTask.TrackingActive = true
-		activeTask.UpdateListTitle()
+		activeTask.trackingActive = true
+		activeTask.updateListTitle()
 
 		// go to tracked item on startup
 		activeIndex, aOk := m.taskIndexMap[msg.activeTask.TaskID]
@@ -795,7 +797,7 @@ func (m *Model) handleTrackingToggledMsg(msg trackingToggledMsg) []tea.Cmd {
 	switch msg.finished {
 	case true:
 		m.lastTrackingChange = trackingFinished
-		task.TrackingActive = false
+		task.trackingActive = false
 		m.activeTLComment = nil
 		m.trackingActive = false
 		m.activeTaskID = -1
@@ -803,12 +805,12 @@ func (m *Model) handleTrackingToggledMsg(msg trackingToggledMsg) []tea.Cmd {
 		cmds = append(cmds, fetchTLS(m.db, nil))
 	case false:
 		m.lastTrackingChange = trackingStarted
-		task.TrackingActive = true
+		task.trackingActive = true
 		m.trackingActive = true
 		m.activeTaskID = msg.taskID
 	}
 
-	task.UpdateListTitle()
+	task.updateListTitle()
 
 	return cmds
 }
@@ -826,8 +828,8 @@ func (m *Model) handleActiveTLSwitchedMsg(msg activeTLSwitchedMsg) tea.Cmd {
 		return nil
 	}
 
-	lastActiveTask.TrackingActive = false
-	lastActiveTask.UpdateListTitle()
+	lastActiveTask.trackingActive = false
+	lastActiveTask.updateListTitle()
 
 	currentlyActiveTask, ok := m.taskMap[msg.currentlyActiveTaskID]
 
@@ -835,8 +837,8 @@ func (m *Model) handleActiveTLSwitchedMsg(msg activeTLSwitchedMsg) tea.Cmd {
 		m.message = errMsg(suggestReloadingMsg)
 		return nil
 	}
-	currentlyActiveTask.TrackingActive = true
-	currentlyActiveTask.UpdateListTitle()
+	currentlyActiveTask.trackingActive = true
+	currentlyActiveTask.updateListTitle()
 
 	m.activeTLComment = nil
 	m.activeTaskID = msg.currentlyActiveTaskID
@@ -873,8 +875,8 @@ func (m *Model) handleActiveTLDeletedMsg(msg activeTaskLogDeletedMsg) {
 		return
 	}
 
-	activeTask.TrackingActive = false
-	activeTask.UpdateListTitle()
+	activeTask.trackingActive = false
+	activeTask.updateListTitle()
 	m.lastTrackingChange = trackingFinished
 	m.trackingActive = false
 	m.activeTLComment = nil

--- a/internal/ui/initial.go
+++ b/internal/ui/initial.go
@@ -70,7 +70,7 @@ This can be used to record details about your work on this task.`
 				style.listItemDescColor,
 				lipgloss.Color(style.theme.InactiveTasks),
 			), listWidth, 0),
-		taskMap:      make(map[int]*types.Task),
+		taskMap:      make(map[int]*taskListItem),
 		taskIndexMap: make(map[int]int),
 		taskLogList: list.New(tasklogListItems,
 			newItemDelegate(

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -108,7 +108,7 @@ type Model struct {
 	timeProvider                   types.TimeProvider
 	activeTasksList                list.Model
 	inactiveTasksList              list.Model
-	taskMap                        map[int]*types.Task
+	taskMap                        map[int]*taskListItem
 	taskIndexMap                   map[int]int
 	activeTLBeginTS                time.Time
 	activeTLEndTS                  time.Time

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"time"
 
+	"github.com/dhth/hours/internal/domain"
 	"github.com/dhth/hours/internal/types"
 )
 
@@ -26,7 +27,7 @@ type activeTLSwitchedMsg struct {
 }
 
 type taskRepUpdatedMsg struct {
-	tsk *types.Task
+	tsk *taskListItem
 	err error
 }
 
@@ -68,13 +69,13 @@ type taskCreatedMsg struct {
 }
 
 type taskUpdatedMsg struct {
-	tsk     *types.Task
+	tsk     *taskListItem
 	summary string
 	err     error
 }
 
 type taskActiveStatusUpdatedMsg struct {
-	tsk    *types.Task
+	tsk    *taskListItem
 	active bool
 	err    error
 }
@@ -85,7 +86,7 @@ type tLDeletedMsg struct {
 }
 
 type tasksFetchedMsg struct {
-	tasks  []types.Task
+	tasks  []domain.Task
 	active bool
 	err    error
 }

--- a/internal/ui/task.go
+++ b/internal/ui/task.go
@@ -1,0 +1,50 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/dhth/hours/internal/domain"
+	"github.com/dhth/hours/internal/types"
+	"github.com/dhth/hours/internal/utils"
+	"github.com/dustin/go-humanize"
+)
+
+type taskListItem struct {
+	domain.Task
+	trackingActive bool
+	listTitle      string
+	listDesc       string
+}
+
+func (t *taskListItem) updateListTitle() {
+	var trackingIndicator string
+	if t.trackingActive {
+		trackingIndicator = "⏲ "
+	}
+
+	t.listTitle = trackingIndicator + t.Summary
+}
+
+func (t *taskListItem) updateListDesc(timeProvider types.TimeProvider) {
+	var timeSpent string
+	if t.SecsSpent != 0 {
+		timeSpent = "worked on for " + types.HumanizeDuration(t.SecsSpent)
+	} else {
+		timeSpent = "no time spent"
+	}
+
+	lastUpdated := fmt.Sprintf("last updated: %s", humanize.RelTime(t.UpdatedAt, timeProvider.Now(), "ago", "from now"))
+	t.listDesc = fmt.Sprintf("%s %s", utils.RightPadTrim(lastUpdated, 60, true), timeSpent)
+}
+
+func (t *taskListItem) Title() string {
+	return t.listTitle
+}
+
+func (t *taskListItem) Description() string {
+	return t.listDesc
+}
+
+func (t *taskListItem) FilterValue() string {
+	return t.Summary
+}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -307,7 +307,7 @@ func (m Model) processMessage(msg tea.Msg) (Model, tea.Cmd) {
 			m.message = errMsg(fmt.Sprintf("Error updating task: %s", msg.err))
 		} else {
 			msg.tsk.Summary = msg.summary
-			msg.tsk.UpdateListTitle()
+			msg.tsk.updateListTitle()
 		}
 	case tasksFetchedMsg:
 		handleCmd := m.handleTasksFetchedMsg(msg)
@@ -349,7 +349,7 @@ func (m Model) processMessage(msg tea.Msg) (Model, tea.Cmd) {
 		if msg.err != nil {
 			m.message = errMsg(fmt.Sprintf("Error updating task status: %s", msg.err))
 		} else {
-			msg.tsk.UpdateListDesc(m.timeProvider)
+			msg.tsk.updateListDesc(m.timeProvider)
 		}
 	case tLDeletedMsg:
 		updateCmds := m.handleTLDeleted(msg)

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
+	"github.com/dhth/hours/internal/domain"
 	"github.com/dhth/hours/internal/types"
 	"github.com/dhth/hours/internal/ui/theme"
 	"github.com/gkampitakis/go-snaps/snaps"
@@ -465,20 +466,22 @@ func createTestModel() Model {
 	return m
 }
 
-func createTestTask(id int, summary string, active bool, trackingActive bool, tp types.TimeProvider) *types.Task {
+func createTestTask(id int, summary string, active bool, trackingActive bool, tp types.TimeProvider) *taskListItem {
 	taskUpdateTime := referenceTime.Add(-3 * time.Hour)
-	task := &types.Task{
-		ID:             id,
-		Summary:        summary,
-		CreatedAt:      taskUpdateTime,
-		UpdatedAt:      taskUpdateTime,
-		TrackingActive: trackingActive,
-		SecsSpent:      0,
-		Active:         active,
+	task := &taskListItem{
+		Task: domain.Task{
+			ID:        id,
+			Summary:   summary,
+			CreatedAt: taskUpdateTime,
+			UpdatedAt: taskUpdateTime,
+			SecsSpent: 0,
+			Active:    active,
+		},
+		trackingActive: trackingActive,
 	}
 
-	task.UpdateListTitle()
-	task.UpdateListDesc(tp)
+	task.updateListTitle()
+	task.updateListDesc(tp)
 
 	return task
 }


### PR DESCRIPTION
Move the core task entity into the domain package while keeping Bubble
Tea list state and behavior in a UI-specific adapter.

Persistence now works directly with domain tasks, and the UI wraps them
at its boundary. This keeps presentation concerns out of the domain
model without changing task behavior.
