### PR TITLE
fix: data race in updateTaskRep tea.Cmd

### DIFF
--- a/internal/persistence/queries.go
+++ b/internal/persistence/queries.go
@@ -27,6 +27,11 @@ type QuickSwitchResult struct {
 	CurrentlyActiveTLID int
 }
 
+type TaskTrackingData struct {
+	SecsSpent int
+	UpdatedAt time.Time
+}
+
 type activeTaskLogEntry struct {
 	ID      int
 	TaskID  int
@@ -422,21 +427,20 @@ WHERE id = ?
 	return nil
 }
 
-func UpdateTaskData(db *sql.DB, t *domain.Task) error {
+func FetchTaskTrackingData(db *sql.DB, taskID int) (TaskTrackingData, error) {
 	row := db.QueryRow(`
 SELECT secs_spent, updated_at
 FROM task
 WHERE id=?;
-    `, t.ID)
+    `, taskID)
 
-	err := row.Scan(
-		&t.SecsSpent,
-		&t.UpdatedAt,
-	)
+	var data TaskTrackingData
+	err := row.Scan(&data.SecsSpent, &data.UpdatedAt)
 	if err != nil {
-		return err
+		return TaskTrackingData{}, err
 	}
-	return nil
+
+	return data, nil
 }
 
 func FetchTasks(db *sql.DB, active bool, limit int) ([]domain.Task, error) {

--- a/internal/ui/cmds.go
+++ b/internal/ui/cmds.go
@@ -109,12 +109,15 @@ func fetchActiveTask(db *sql.DB) tea.Cmd {
 	}
 }
 
-func updateTaskRep(db *sql.DB, t *taskListItem) tea.Cmd {
+func fetchTaskTrackingData(db *sql.DB, taskID int) tea.Cmd {
 	return func() tea.Msg {
-		err := pers.UpdateTaskData(db, &t.Task)
-		return taskRepUpdatedMsg{
-			tsk: t,
-			err: err,
+		data, err := pers.FetchTaskTrackingData(db, taskID)
+
+		return taskTrackingDataFetchedMsg{
+			taskID:    taskID,
+			secsSpent: data.SecsSpent,
+			updatedAt: data.UpdatedAt,
+			err:       err,
 		}
 	}
 }

--- a/internal/ui/handle.go
+++ b/internal/ui/handle.go
@@ -692,11 +692,9 @@ func (m *Model) handleManualTLInsertedMsg(msg manualTLInsertedMsg) []tea.Cmd {
 		return nil
 	}
 
-	task, ok := m.taskMap[msg.taskID]
-
 	var cmds []tea.Cmd
-	if ok {
-		cmds = append(cmds, updateTaskRep(m.db, task))
+	if _, ok := m.taskMap[msg.taskID]; ok {
+		cmds = append(cmds, fetchTaskTrackingData(m.db, msg.taskID))
 	}
 	cmds = append(cmds, fetchTLS(m.db, nil))
 
@@ -709,11 +707,9 @@ func (m *Model) handleSavedTLEditedMsg(msg savedTLEditedMsg) []tea.Cmd {
 		return nil
 	}
 
-	task, ok := m.taskMap[msg.taskID]
-
 	var cmds []tea.Cmd
-	if ok {
-		cmds = append(cmds, updateTaskRep(m.db, task))
+	if _, ok := m.taskMap[msg.taskID]; ok {
+		cmds = append(cmds, fetchTaskTrackingData(m.db, msg.taskID))
 	}
 	cmds = append(cmds, fetchTLS(m.db, &msg.tlID))
 
@@ -802,7 +798,7 @@ func (m *Model) handleTrackingToggledMsg(msg trackingToggledMsg) []tea.Cmd {
 		m.activeTLComment = nil
 		m.trackingActive = false
 		m.activeTaskID = -1
-		cmds = append(cmds, updateTaskRep(m.db, task))
+		cmds = append(cmds, fetchTaskTrackingData(m.db, msg.taskID))
 		cmds = append(cmds, fetchTLS(m.db, nil))
 	case false:
 		m.lastTrackingChange = trackingStarted
@@ -855,9 +851,8 @@ func (m *Model) handleTLDeleted(msg tLDeletedMsg) []tea.Cmd {
 	}
 
 	var cmds []tea.Cmd
-	task, ok := m.taskMap[msg.entry.TaskID]
-	if ok {
-		cmds = append(cmds, updateTaskRep(m.db, task))
+	if _, ok := m.taskMap[msg.entry.TaskID]; ok {
+		cmds = append(cmds, fetchTaskTrackingData(m.db, msg.entry.TaskID))
 	}
 	cmds = append(cmds, fetchTLS(m.db, nil))
 

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -26,9 +26,11 @@ type activeTLSwitchedMsg struct {
 	err                   error
 }
 
-type taskRepUpdatedMsg struct {
-	tsk *taskListItem
-	err error
+type taskTrackingDataFetchedMsg struct {
+	taskID    int
+	secsSpent int
+	updatedAt time.Time
+	err       error
 }
 
 type manualTLInsertedMsg struct {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -345,11 +345,18 @@ func (m Model) processMessage(msg tea.Msg) (Model, tea.Cmd) {
 		if updateCmd != nil {
 			cmds = append(cmds, updateCmd)
 		}
-	case taskRepUpdatedMsg:
+	case taskTrackingDataFetchedMsg:
 		if msg.err != nil {
 			m.message = errMsg(fmt.Sprintf("Error updating task status: %s", msg.err))
 		} else {
-			msg.tsk.updateListDesc(m.timeProvider)
+			task, ok := m.taskMap[msg.taskID]
+			if !ok {
+				break
+			}
+
+			task.SecsSpent = msg.secsSpent
+			task.UpdatedAt = msg.updatedAt
+			task.updateListDesc(m.timeProvider)
 		}
 	case tLDeletedMsg:
 		updateCmds := m.handleTLDeleted(msg)


### PR DESCRIPTION
Task refresh commands now query by ID and return tracking data through a
bubble tea message. Model-owned task state is updated only in the
message handler, avoiding asynchronous mutation of live UI objects.
