### PR TITLE
update time spent on task on quick switch

### DIFF
--- a/internal/ui/handle.go
+++ b/internal/ui/handle.go
@@ -841,7 +841,10 @@ func (m *Model) handleActiveTLSwitchedMsg(msg activeTLSwitchedMsg) tea.Cmd {
 	m.activeTaskID = msg.currentlyActiveTaskID
 	m.activeTLBeginTS = msg.ts
 
-	return fetchTLS(m.db, nil)
+	return tea.Batch(
+		fetchTaskTrackingData(m.db, msg.lastActiveTaskID),
+		fetchTLS(m.db, nil),
+	)
 }
 
 func (m *Model) handleTLDeleted(msg tLDeletedMsg) []tea.Cmd {


### PR DESCRIPTION
Refresh the previous task’s accumulated time and last-updated
description after quick switching, alongside the existing task-log
refresh.
