### PR TITLE
make go version explicit in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,10 +1,10 @@
 [settings]
-idiomatic_version_file_enable_tools = ["go"]
 task.run_auto_install = false
 
 [tools]
 actionlint = "1.7.12"
 cosign = "2.5.3"
+go = "1.27.0"
 "go:golang.org/x/vuln/cmd/govulncheck" = "latest"
 gofumpt = "0.11.0"
 golangci-lint = "2.13.1"


### PR DESCRIPTION
mise is deprecating deriving the tool version from the go directive
because it only declares the minimum compatible version:

Pin the current Go version in mise.toml so builds continue using the
intended toolchain after this behavior is removed in mise 2026.11.0.
